### PR TITLE
Add github-actions ecosystem to Dependabot, bound PR limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@ updates:
     schedule:
       interval: "daily"
       time: "10:00"
-    open-pull-requests-limit: 1000
+    open-pull-requests-limit: 10
+    assignees:
+      - "michaelbel"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+    open-pull-requests-limit: 10
     assignees:
       - "michaelbel"


### PR DESCRIPTION
## Summary
- Adds a `github-actions` entry to `.github/dependabot.yml` so actions like `actions/checkout`, `actions/cache`, `actions/setup-java` get automatic version/security bumps.
- Lowers `open-pull-requests-limit` from 1000 to 10 for both ecosystems.

Fixes #635

## Test plan
- [x] `.github/dependabot.yml` validated as YAML and checked against expected structure (two ecosystems, both limits = 10)