### PR TITLE
Lower Gradle JVM heap and enable build cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
-org.gradle.jvmargs=-Xmx20480m
+org.gradle.jvmargs=-Xmx6144m
 org.gradle.parallel=true
+org.gradle.caching=true
 org.gradle.tooling.parallel=true
 android.useAndroidX=true
 android.enableJetifier=false


### PR DESCRIPTION
## Summary
- `org.gradle.jvmargs`: `-Xmx20480m` → `-Xmx6144m` — the old value was sized for a local dev machine, not the `ubuntu-24.04` GitHub-hosted runners this project actually builds on.
- Adds `org.gradle.caching=true` to enable the Gradle build cache.

Fixes #636

## Test plan
- [x] `./gradlew detekt testFossDebugUnitTest androidApp:assembleFossDebug` passes locally with the new settings