### PR TITLE
Fix unhandled device system locale fallback and lazy screen capture c…

### DIFF
--- a/androidApp/src/main/kotlin/org/michaelbel/movies/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/michaelbel/movies/MainActivity.kt
@@ -28,14 +28,13 @@ class MainActivity: FragmentActivity() {
 
     private val viewModel: MainViewModel by viewModel()
 
-    private val screenCaptureCallback: Any
-        get() {
-            return if (Build.VERSION.SDK_INT >= 34) {
-                ScreenCaptureCallback {}
-            } else {
-                Unit
-            }
+    private val screenCaptureCallback: Any by lazy {
+        if (Build.VERSION.SDK_INT >= 34) {
+            ScreenCaptureCallback {}
+        } else {
+            Unit
         }
+    }
 
     private val Uri.tmdbMovieId: Int?
         get() {

--- a/shared-web/interactor/src/commonMain/kotlin/org/michaelbel/movies/interactor/entity/AppLanguage.kt
+++ b/shared-web/interactor/src/commonMain/kotlin/org/michaelbel/movies/interactor/entity/AppLanguage.kt
@@ -20,10 +20,9 @@ sealed interface AppLanguage: SealedString {
         )
 
         fun transform(code: String): AppLanguage {
-            return when (code) {
-                "en" -> English()
-                "ru" -> Russian()
-                else -> throw InvalidLocaleException()
+            return when {
+                code.startsWith("ru", ignoreCase = true) -> Russian()
+                else -> English()
             }
         }
 

--- a/shared/interactor/src/commonMain/kotlin/org/michaelbel/movies/interactor/entity/AppLanguage.kt
+++ b/shared/interactor/src/commonMain/kotlin/org/michaelbel/movies/interactor/entity/AppLanguage.kt
@@ -20,10 +20,9 @@ sealed interface AppLanguage: SealedString {
         )
 
         fun transform(code: String): AppLanguage {
-            return when (code) {
-                "en" -> English()
-                "ru" -> Russian()
-                else -> throw InvalidLocaleException()
+            return when {
+                code.startsWith("ru", ignoreCase = true) -> Russian()
+                else -> English()
             }
         }
 


### PR DESCRIPTION
...allback

**Task:**

Fix Android startup failures caused by unsupported system locale values and stabilize the screen capture callback lifecycle.

- Make unsupported device locales fall back safely to English instead of throwing `InvalidLocaleException`.
- Preserve Russian when the locale starts with `ru`.
- Apply the same locale fallback behavior to both shared and shared-web implementations.
- Initialize the Android 14+ `ScreenCaptureCallback` lazily and keep a stable callback instance instead of recreating it on every access.
- Prevent the application from closing during startup on devices whose system locale is not explicitly supported.
- Validated on a physical Samsung Galaxy S25 Ultra.

**Screenshots:**

Not applicable. This PR fixes startup/runtime behavior and does not introduce user-facing UI changes.

<div style="dispaly:flex">
    <!-- No screenshots required -->
</div>