### PR TITLE
Add network connectivity monitoring and transport failure diagnostics

### DIFF
--- a/.github/detekt.yml
+++ b/.github/detekt.yml
@@ -15,6 +15,9 @@ naming:
 complexity:
   CyclomaticComplexMethod:
     active: false
+  LargeClass:
+    excludes:
+      - '**/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt'
   LongMethod:
     active: false
   LongParameterList:

--- a/CONNECTIVITY_TESTING.md
+++ b/CONNECTIVITY_TESTING.md
@@ -1,0 +1,38 @@
+# Network Connectivity Monitoring & Diagnostics
+
+This module integrates connectivity observation and failure diagnostics based on [`ConnectivityAndInternetAccess.kt`](https://gist.github.com/rodrigosambadesaa/729cca29a031fef4e2f15751863b655f) into the Movies networking stack.
+
+## Architecture & Design
+
+Normal operation performs **no connectivity pre-flight** before backend requests:
+
+1. **Passive observation**: An application-level `NetworkObserver` follows Android's default network state passively without sending any network traffic.
+2. **Transparent execution**: Ktor/OkHttp executes normal TMDb API requests directly.
+3. **Failure-triggered active diagnostics**: Active network diagnosis is initiated **only when** a transport `IOException` (such as a connection failure or DNS error) is encountered.
+4. **App-first domain probes**:
+   - First, the diagnostic resolves the specific domains used by Movies:
+     - `api.themoviedb.org`
+     - `image.tmdb.org`
+     - `themoviedb.org`
+     - `www.themoviedb.org`
+     - `www.gravatar.com`
+   - Next, HTTPS reachability probes are run against the application endpoints.
+5. **Generic fallback**: Only if all application-specific probes fail does the generic fallback run (checking system DNS, public DNS resolvers, and general HTTPS probe targets).
+
+HTTP response errors (such as 401, 404, or 500) are valid HTTP responses and do not trigger network diagnostics. The interceptor always rethrows the original transport exception unchanged.
+
+## Testing & Logcat Inspection
+
+Filter Logcat by tag:
+
+```text
+MoviesConnectivity
+```
+
+### Verification Scenarios
+
+1. **Normal network connection**: Browse and search movies. The passive observer reports default network changes; no active diagnostics run.
+2. **Network switching**: Switch between Wi-Fi and Cellular. The observer emits updated default-network states without active polling.
+3. **No network connection**: When all network interfaces are disabled, `connected=false` is reported. If a backend request fails, active probes are skipped because the network is known to be offline.
+4. **Domain-specific reachability failure**: If TMDb endpoints are blocked while general Internet works, app-domain DNS/HTTPS probes fail first, and generic fallback reports general Internet availability.
+5. **Active Diagnostic Guards**: Active diagnostics implement a 5-second cooldown and single-flight execution to prevent probe spam during burst request failures.

--- a/CONNECTIVITY_TESTING.md
+++ b/CONNECTIVITY_TESTING.md
@@ -4,20 +4,12 @@ This module integrates connectivity observation and failure diagnostics based on
 
 ## Architecture & Design
 
-Normal operation performs **no connectivity pre-flight** before backend requests:
+Normal operation performs a **cheap local guard** before a new remote operation:
 
-1. **Passive observation**: An application-level `NetworkObserver` follows Android's default network state passively without sending any network traffic.
-2. **Transparent execution**: Ktor/OkHttp executes normal TMDb API requests directly.
-3. **Failure-triggered active diagnostics**: Active network diagnosis is initiated **only when** a transport `IOException` (such as a connection failure or DNS error) is encountered.
-4. **App-first domain probes**:
-   - First, the diagnostic resolves the specific domains used by Movies:
-     - `api.themoviedb.org`
-     - `image.tmdb.org`
-     - `themoviedb.org`
-     - `www.themoviedb.org`
-     - `www.gravatar.com`
-   - Next, HTTPS reachability probes are run against the application endpoints.
-5. **Generic fallback**: Only if all application-specific probes fail does the generic fallback run (checking system DNS, public DNS resolvers, and general HTTPS probe targets).
+1. **Local policy**: the operation is allowed only when `isConnected(context)` and `hasPhysicalNetwork(context)` are both true. This prevents a dangling VPN-only network from starting a request.
+2. **Passive observation**: an application-level `NetworkObserver` follows Android's default network state and normalizes it with the physical-transport check, without sending network traffic.
+3. **Transparent execution**: Ktor/OkHttp and dynamic Coil resources execute their real operation directly after the local guard; redirects, CDNs and multiple hosts are not pre-enumerated.
+4. **Failure-triggered active diagnostics**: active generic diagnosis is initiated only after a transport `IOException` such as a connection failure, DNS error or timeout.
 
 HTTP response errors (such as 401, 404, or 500) are valid HTTP responses and do not trigger network diagnostics. The interceptor always rethrows the original transport exception unchanged.
 
@@ -32,7 +24,8 @@ MoviesConnectivity
 ### Verification Scenarios
 
 1. **Normal network connection**: Browse and search movies. The passive observer reports default network changes; no active diagnostics run.
-2. **Network switching**: Switch between Wi-Fi and Cellular. The observer emits updated default-network states without active polling.
-3. **No network connection**: When all network interfaces are disabled, `connected=false` is reported. If a backend request fails, active probes are skipped because the network is known to be offline.
-4. **Domain-specific reachability failure**: If TMDb endpoints are blocked while general Internet works, app-domain DNS/HTTPS probes fail first, and generic fallback reports general Internet availability.
-5. **Active Diagnostic Guards**: Active diagnostics implement a 5-second cooldown and single-flight execution to prevent probe spam during burst request failures.
+2. **Network switching**: switch between Wi-Fi and Cellular. The observer emits updated states without active polling.
+3. **VPN-only / AdGuard**: with VPN active and Wi-Fi/cellular/Ethernet disabled, `isConnected` may remain true but `hasPhysicalNetwork=false`; the normalized state is offline and new requests are not started.
+4. **VPN recovery**: restore Wi-Fi or cellular while the VPN remains active. The observer publishes an available state and new requests are allowed again.
+5. **Portal/validation**: `internetValidated` and `captivePortalDetected` remain separate passive Android signals; neither replaces the physical-network guard.
+6. **Active Diagnostic Guards**: active diagnostics implement a 5-second cooldown and single-flight execution to prevent probe spam during burst request failures.

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -141,6 +141,7 @@ dependencies {
     fossImplementation(projects.shared.platformServices.injectAndroid)
     implementation(projects.feature.main)
     implementation(libs.bundles.kotlin.reflect.android)
+    testImplementation(projects.shared.network)
     testImplementation(libs.bundles.junit.android)
     androidTestImplementation(libs.bundles.test.espresso.android)
     androidTestImplementation(libs.bundles.test.ext.junit.android)

--- a/androidApp/src/main/kotlin/org/michaelbel/movies/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/michaelbel/movies/MainActivity.kt
@@ -4,16 +4,24 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.getValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.Lifecycle
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.michaelbel.movies.main.MainScreen
 import org.michaelbel.movies.main.MainViewModel
 import org.michaelbel.movies.main.intent.MainIntent
+import org.michaelbel.movies.network.connectivity.impl.ConnectivityUiEvent
+import org.michaelbel.movies.network.connectivity.impl.MoviesConnectivityMonitor
 import org.michaelbel.movies.ui.collectAsStateCommon
 import org.michaelbel.movies.ui.resolveNotificationPreferencesIntent
 import org.michaelbel.movies.ui.setScreenshotBlockEnabled
@@ -27,6 +35,7 @@ import org.michaelbel.movies.ui.theme.AppTheme
 class MainActivity: FragmentActivity() {
 
     private val viewModel: MainViewModel by viewModel()
+    private val connectivityMonitor: MoviesConnectivityMonitor by inject()
 
     private val screenCaptureCallback: Any
         get() {
@@ -51,6 +60,21 @@ class MainActivity: FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen().apply { setKeepOnScreenCondition { viewModel.stateFlow.value.splashLoading } }
         super.onCreate(savedInstanceState)
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                connectivityMonitor.uiEvents.collect { event ->
+                    val message = when (event) {
+                        ConnectivityUiEvent.NetworkLost,
+                        ConnectivityUiEvent.NoNetworkForOperation -> R.string.connectivity_no_network_operation
+                        ConnectivityUiEvent.NetworkRecovered -> R.string.connectivity_network_recovered
+                        ConnectivityUiEvent.CaptivePortal -> R.string.connectivity_captive_portal
+                        ConnectivityUiEvent.InternetUnavailable -> R.string.connectivity_internet_unavailable
+                        ConnectivityUiEvent.BackendUnavailable -> R.string.connectivity_backend_unavailable
+                    }
+                    Toast.makeText(this@MainActivity, message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
         installShortcuts()
         setContent {
             val state by viewModel.stateFlow.collectAsStateCommon()

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -2,4 +2,10 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" translatable="false" tools:ignore="UnusedResources">Movies</string>
     <string name="app_name_dev" translatable="false" tools:ignore="UnusedResources">Movies Dev</string>
+    <string name="connectivity_network_lost">No network connection.</string>
+    <string name="connectivity_network_recovered">Connection restored.</string>
+    <string name="connectivity_captive_portal">This network requires sign-in to access the Internet.</string>
+    <string name="connectivity_no_network_operation">No network connection.</string>
+    <string name="connectivity_internet_unavailable">Internet is unavailable.</string>
+    <string name="connectivity_backend_unavailable">Internet is available, but the service is unavailable.</string>
 </resources>

--- a/androidApp/src/test/kotlin/org/michaelbel/movies/connectivity/ConnectivityFallbackPolicyTest.kt
+++ b/androidApp/src/test/kotlin/org/michaelbel/movies/connectivity/ConnectivityFallbackPolicyTest.kt
@@ -1,96 +1,54 @@
 package org.michaelbel.movies.connectivity
 
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.michaelbel.movies.network.connectivity.ConnectivityFallbackPolicy
 import org.michaelbel.movies.network.connectivity.ConnectivityTierResult
-import org.michaelbel.movies.network.connectivity.MoviesConnectivityTargets
 
 class ConnectivityFallbackPolicyTest {
     private val policy = ConnectivityFallbackPolicy()
 
     @Test
-    fun generalProbeIsSkippedWhenAnyMoviesEndpointIsReachable() {
+    fun generalProbeRunsAfterTheRealBackendOperationFails() {
         var generalCalls = 0
 
         val result = policy.diagnose(
-            applicationProbe = {
-                ConnectivityTierResult(
-                    reachable = true,
-                    reachedEndpoint = "https://api.themoviedb.org/3/",
-                    attemptedEndpoints = MoviesConnectivityTargets.backendProbeUrls
-                )
-            },
+            failedTarget = "api.themoviedb.org",
             generalProbe = {
                 generalCalls++
                 ConnectivityTierResult(true, "https://www.google.com/generate_204", emptyList())
             }
         )
 
-        assertEquals(0, generalCalls)
-        assertTrue(result.applicationTier.reachable)
-        assertFalse(result.usedGeneralFallback)
-        assertNull(result.generalTier)
+        assertTrue(generalCalls == 1)
+        assertFalse(result.applicationTier.reachable)
+        assertTrue(result.usedGeneralFallback)
+        assertTrue(result.generalTier?.reachable == true)
+        assertTrue(result.reachable)
+        assertTrue(result.applicationTier.attemptedEndpoints == listOf("api.themoviedb.org"))
     }
 
     @Test
-    fun generalProbeRunsOnlyAfterCompleteMoviesTierFails() {
+    fun generalProbeReportsGeneralInternetFailure() {
         var generalCalls = 0
 
         val result = policy.diagnose(
-            applicationProbe = {
-                ConnectivityTierResult(
-                    reachable = false,
-                    reachedEndpoint = null,
-                    attemptedEndpoints = MoviesConnectivityTargets.backendProbeUrls
-                )
-            },
+            failedTarget = "api.themoviedb.org",
             generalProbe = {
                 generalCalls++
                 ConnectivityTierResult(
-                    reachable = true,
-                    reachedEndpoint = "dns://system/example.com",
+                    reachable = false,
+                    reachedEndpoint = null,
                     attemptedEndpoints = listOf("dns://system/example.com")
                 )
             }
         )
 
-        assertEquals(1, generalCalls)
+        assertTrue(generalCalls == 1)
         assertFalse(result.applicationTier.reachable)
         assertTrue(result.usedGeneralFallback)
-        assertTrue(result.generalTier?.reachable == true)
-        assertTrue(result.reachable)
-    }
-
-    @Test
-    fun moviesTierContainsOnlyDestinationsUsedByTheApp() {
-        assertEquals(
-            listOf(
-                "api.themoviedb.org",
-                "image.tmdb.org",
-                "themoviedb.org",
-                "www.themoviedb.org",
-                "www.gravatar.com"
-            ),
-            MoviesConnectivityTargets.backendDomains
-        )
-
-        assertTrue(
-            MoviesConnectivityTargets.backendProbeUrls.all { url ->
-                MoviesConnectivityTargets.backendDomains.any { domain -> url.contains(domain) }
-            }
-        )
-        assertFalse(
-            MoviesConnectivityTargets.backendProbeUrls.any { url ->
-                url.contains("google.com") ||
-                    url.contains("facebook.com") ||
-                    url.contains("apple.com") ||
-                    url.contains("amazon.com") ||
-                    url.contains("wolframalpha.com")
-            }
-        )
+        assertFalse(result.generalTier?.reachable == true)
+        assertFalse(result.reachable)
     }
 }

--- a/androidApp/src/test/kotlin/org/michaelbel/movies/connectivity/ConnectivityFallbackPolicyTest.kt
+++ b/androidApp/src/test/kotlin/org/michaelbel/movies/connectivity/ConnectivityFallbackPolicyTest.kt
@@ -1,0 +1,96 @@
+package org.michaelbel.movies.connectivity
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.michaelbel.movies.network.connectivity.ConnectivityFallbackPolicy
+import org.michaelbel.movies.network.connectivity.ConnectivityTierResult
+import org.michaelbel.movies.network.connectivity.MoviesConnectivityTargets
+
+class ConnectivityFallbackPolicyTest {
+    private val policy = ConnectivityFallbackPolicy()
+
+    @Test
+    fun generalProbeIsSkippedWhenAnyMoviesEndpointIsReachable() {
+        var generalCalls = 0
+
+        val result = policy.diagnose(
+            applicationProbe = {
+                ConnectivityTierResult(
+                    reachable = true,
+                    reachedEndpoint = "https://api.themoviedb.org/3/",
+                    attemptedEndpoints = MoviesConnectivityTargets.backendProbeUrls
+                )
+            },
+            generalProbe = {
+                generalCalls++
+                ConnectivityTierResult(true, "https://www.google.com/generate_204", emptyList())
+            }
+        )
+
+        assertEquals(0, generalCalls)
+        assertTrue(result.applicationTier.reachable)
+        assertFalse(result.usedGeneralFallback)
+        assertNull(result.generalTier)
+    }
+
+    @Test
+    fun generalProbeRunsOnlyAfterCompleteMoviesTierFails() {
+        var generalCalls = 0
+
+        val result = policy.diagnose(
+            applicationProbe = {
+                ConnectivityTierResult(
+                    reachable = false,
+                    reachedEndpoint = null,
+                    attemptedEndpoints = MoviesConnectivityTargets.backendProbeUrls
+                )
+            },
+            generalProbe = {
+                generalCalls++
+                ConnectivityTierResult(
+                    reachable = true,
+                    reachedEndpoint = "dns://system/example.com",
+                    attemptedEndpoints = listOf("dns://system/example.com")
+                )
+            }
+        )
+
+        assertEquals(1, generalCalls)
+        assertFalse(result.applicationTier.reachable)
+        assertTrue(result.usedGeneralFallback)
+        assertTrue(result.generalTier?.reachable == true)
+        assertTrue(result.reachable)
+    }
+
+    @Test
+    fun moviesTierContainsOnlyDestinationsUsedByTheApp() {
+        assertEquals(
+            listOf(
+                "api.themoviedb.org",
+                "image.tmdb.org",
+                "themoviedb.org",
+                "www.themoviedb.org",
+                "www.gravatar.com"
+            ),
+            MoviesConnectivityTargets.backendDomains
+        )
+
+        assertTrue(
+            MoviesConnectivityTargets.backendProbeUrls.all { url ->
+                MoviesConnectivityTargets.backendDomains.any { domain -> url.contains(domain) }
+            }
+        )
+        assertFalse(
+            MoviesConnectivityTargets.backendProbeUrls.any { url ->
+                url.contains("google.com") ||
+                    url.contains("facebook.com") ||
+                    url.contains("apple.com") ||
+                    url.contains("amazon.com") ||
+                    url.contains("wolframalpha.com")
+            }
+        )
+    }
+}

--- a/androidApp/src/test/kotlin/org/michaelbel/movies/connectivity/RemoteConnectivityPolicyTest.kt
+++ b/androidApp/src/test/kotlin/org/michaelbel/movies/connectivity/RemoteConnectivityPolicyTest.kt
@@ -1,0 +1,38 @@
+package org.michaelbel.movies.connectivity
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.michaelbel.movies.network.connectivity.RemoteConnectivityPolicy
+
+class RemoteConnectivityPolicyTest {
+    @Test
+    fun normalNetworkAllowsRemoteOperation() {
+        assertTrue(RemoteConnectivityPolicy.canStartRemoteRequest(true, true))
+    }
+
+    @Test
+    fun vpnOverPhysicalNetworkAllowsRemoteOperation() {
+        assertTrue(RemoteConnectivityPolicy.canStartRemoteRequest(true, true))
+    }
+
+    @Test
+    fun vpnOnlyNetworkIsOfflineEvenWhenConnectedSignalIsTrue() {
+        assertFalse(RemoteConnectivityPolicy.canStartRemoteRequest(true, false))
+    }
+
+    @Test
+    fun recoveryAllowsRemoteOperationAgain() {
+        assertTrue(RemoteConnectivityPolicy.canStartRemoteRequest(true, true))
+    }
+
+    @Test
+    fun noNetworkIsOffline() {
+        assertFalse(RemoteConnectivityPolicy.canStartRemoteRequest(false, false))
+    }
+
+    @Test
+    fun unvalidatedPhysicalNetworkIsNotBlockedByValidationSignal() {
+        assertTrue(RemoteConnectivityPolicy.canStartRemoteRequest(true, true))
+    }
+}

--- a/shared/interactor/src/androidMain/kotlin/org/michaelbel/movies/interactor/impl/LocaleInteractorImpl.kt
+++ b/shared/interactor/src/androidMain/kotlin/org/michaelbel/movies/interactor/impl/LocaleInteractorImpl.kt
@@ -23,24 +23,28 @@ class LocaleInteractorImpl(
     private val analytics: MoviesAnalytics
 ): LocaleInteractor {
 
+    private fun String?.supportedLanguageCode(): String? {
+        return takeIf { it == AppLanguage.English().code || it == AppLanguage.Russian().code }
+    }
+
     override val language: String
         get() {
             val appCompatLocales = AppCompatDelegate.getApplicationLocales()
             val appCompatLanguage = if (appCompatLocales.size() > 0) appCompatLocales[0]?.language else null
-            if (!appCompatLanguage.isNullOrBlank()) return appCompatLanguage
+            appCompatLanguage.supportedLanguageCode()?.let { return it }
 
             if (Build.VERSION.SDK_INT >= 33) {
                 val localeManager = ContextCompat.getSystemService(context, LocaleManager::class.java)
                 if (localeManager != null) {
                     val frameworkLocales = localeManager.applicationLocales
                     val frameworkLanguage = if (frameworkLocales.size() > 0) frameworkLocales[0].language else null
-                    if (!frameworkLanguage.isNullOrBlank()) return frameworkLanguage
+                    frameworkLanguage.supportedLanguageCode()?.let { return it }
                 }
             }
 
             val resourcesLocales = context.resources.configuration.locales
             val resourcesLanguage = if (resourcesLocales.size() > 0) resourcesLocales[0].language else null
-            return resourcesLanguage?.takeIf(String::isNotBlank) ?: AppLanguage.English().code
+            return resourcesLanguage.supportedLanguageCode() ?: AppLanguage.English().code
         }
 
     override val appLanguage: Flow<AppLanguage> = flowOf(AppLanguage.transform(language))

--- a/shared/network/src/androidMain/kotlin/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt
+++ b/shared/network/src/androidMain/kotlin/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt
@@ -1,0 +1,1626 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Based on Connectivity.java by Emil Davtyan (emil2k), later modified by str4d.
+ * Further modernized by Rodrigo Sambade Saá for thread-safety, Android API
+ * compatibility, extensible probe strategies, captive-portal-aware reachability
+ * checks, and passive default-network observation.
+ *
+ * Source integrated from:
+ * https://gist.github.com/rodrigosambadesaa/729cca29a031fef4e2f15751863b655f
+ */
+@file:Suppress("DEPRECATION")
+
+package net.i2p.android.router.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkInfo
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.provider.Settings
+import android.telephony.TelephonyManager
+import java.io.Closeable
+import java.io.IOException
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.HttpURLConnection
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.URL
+import java.net.URLConnection
+import java.security.GeneralSecurityException
+import java.util.ArrayDeque
+import java.util.concurrent.Callable
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorCompletionService
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+
+class ConnectivityAndInternetAccess private constructor(
+    private val instanceHosts: List<String>,
+    private val instanceResolvers: List<String>,
+    private val instanceDnsStrategy: DnsProbeStrategy,
+    private val instanceHttpStrategy: HttpProbeStrategy
+) {
+
+    /**
+     * Legacy constructor retained for compatibility. It also updates the global host list,
+     * matching the historical mutable-global behavior. New code should prefer Builder.
+     */
+    constructor(hosts: ArrayList<String>) : this(
+        normalizeHosts(hosts),
+        DEFAULT_DNS_RESOLVERS,
+        DefaultDnsProbe(),
+        DefaultHttpProbe()
+    ) {
+        globalHosts = instanceHosts
+    }
+
+    fun interface DnsProbeStrategy {
+        fun checkDns(resolver: String, network: Network?): Boolean
+    }
+
+    fun interface HttpProbeStrategy {
+        fun checkHttp(address: String, network: Network?): Boolean
+    }
+
+    fun interface InternetCallback {
+        fun onResult(result: InternetResult)
+    }
+
+    @ConsistentCopyVisibility
+    data class InternetResult internal constructor(
+        val reachable: Boolean,
+        val reachedHost: String?,
+        val attemptedHosts: List<String>,
+        val elapsedMilliseconds: Long
+    ) {
+        fun isReachable(): Boolean = reachable
+    }
+
+    class Request internal constructor() {
+        private val cancelled = AtomicBoolean(false)
+
+        @Volatile
+        private var future: Future<*>? = null
+
+        fun cancel() {
+            cancelled.set(true)
+            future?.cancel(true)
+        }
+
+        fun isCancelled(): Boolean = cancelled.get()
+
+        internal fun attach(task: Future<*>) {
+            future = task
+            if (cancelled.get()) {
+                task.cancel(true)
+            }
+        }
+    }
+
+    fun interface NetworkStateCallback {
+        fun onStateChanged(state: NetworkState)
+    }
+
+    /** Cheap passive state of the application's default network. */
+    @ConsistentCopyVisibility
+    data class NetworkState internal constructor(
+        val connected: Boolean,
+        val internetValidated: Boolean,
+        val captivePortalDetected: Boolean,
+        val observedAtElapsedRealtime: Long
+    ) {
+        internal fun sameConnectivityState(other: NetworkState): Boolean =
+            connected == other.connected &&
+                internetValidated == other.internetValidated &&
+                captivePortalDetected == other.captivePortalDetected
+    }
+
+    /**
+     * Lifecycle-friendly passive observer. API 24+ uses the application's default
+     * NetworkCallback. API 16-23 uses a dynamically registered CONNECTIVITY_ACTION
+     * receiver because registerDefaultNetworkCallback() did not exist before API 24.
+     * The observer itself sends no DNS or HTTP traffic.
+     */
+    class NetworkObserver internal constructor(
+        context: Context,
+        private val callback: NetworkStateCallback
+    ) : Closeable {
+        private val applicationContext: Context = context.applicationContext ?: context
+        private val connectivityManager = manager(applicationContext)
+        private val closed = AtomicBoolean(false)
+
+        @Volatile
+        private var latestState: NetworkState = snapshotNetworkState(applicationContext)
+
+        private var networkCallback: ConnectivityManager.NetworkCallback? = null
+        private var legacyReceiver: BroadcastReceiver? = null
+
+        init {
+            deliver(latestState)
+            register()
+        }
+
+        fun getLatestState(): NetworkState = latestState
+
+        private fun register() {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                val observerCallback = object : ConnectivityManager.NetworkCallback() {
+                    @Volatile
+                    private var currentDefaultNetwork: Network? = null
+
+                    override fun onAvailable(network: Network) {
+                        // Android recommends waiting for onCapabilitiesChanged instead of
+                        // synchronously querying capabilities from onAvailable.
+                        currentDefaultNetwork = network
+                    }
+
+                    override fun onCapabilitiesChanged(
+                        network: Network,
+                        networkCapabilities: NetworkCapabilities
+                    ) {
+                        currentDefaultNetwork = network
+                        publish(networkStateFromCapabilities(networkCapabilities))
+                    }
+
+                    override fun onLost(network: Network) {
+                        if (network == currentDefaultNetwork) {
+                            currentDefaultNetwork = null
+                            publish(disconnectedNetworkState())
+                        }
+                    }
+                }
+                networkCallback = observerCallback
+                connectivityManager.registerDefaultNetworkCallback(observerCallback)
+                return
+            }
+
+            val receiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context?, intent: Intent?) {
+                    publish(snapshotNetworkState(applicationContext))
+                }
+            }
+            legacyReceiver = receiver
+            applicationContext.registerReceiver(
+                receiver,
+                IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+            )
+        }
+
+        private fun publish(state: NetworkState) {
+            if (closed.get()) return
+            val previous = latestState
+            latestState = state
+            if (!state.sameConnectivityState(previous)) {
+                deliver(state)
+            }
+        }
+
+        private fun deliver(state: NetworkState) {
+            mainHandler.post {
+                if (!closed.get()) {
+                    callback.onStateChanged(state)
+                }
+            }
+        }
+
+        override fun close() {
+            if (!closed.compareAndSet(false, true)) return
+
+            networkCallback?.let { registered ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    try {
+                        connectivityManager.unregisterNetworkCallback(registered)
+                    } catch (_: IllegalArgumentException) {
+                        // Already unregistered or registration failed during teardown.
+                    }
+                }
+            }
+            networkCallback = null
+
+            legacyReceiver?.let { receiver ->
+                try {
+                    applicationContext.unregisterReceiver(receiver)
+                } catch (_: IllegalArgumentException) {
+                    // Receiver was already unregistered.
+                }
+            }
+            legacyReceiver = null
+        }
+    }
+
+    class Builder {
+        private var hosts: List<String> = DEFAULT_HOSTS
+        private var dnsResolvers: List<String> = DEFAULT_DNS_RESOLVERS
+        private var dnsStrategy: DnsProbeStrategy = DefaultDnsProbe()
+        private var httpStrategy: HttpProbeStrategy = DefaultHttpProbe()
+
+        fun setHosts(hosts: List<String>) = apply {
+            this.hosts = hosts
+        }
+
+        fun setDnsResolvers(resolvers: List<String>) = apply {
+            this.dnsResolvers = resolvers
+        }
+
+        fun setDnsProbeStrategy(strategy: DnsProbeStrategy) = apply {
+            this.dnsStrategy = strategy
+        }
+
+        fun setHttpProbeStrategy(strategy: HttpProbeStrategy) = apply {
+            this.httpStrategy = strategy
+        }
+
+        fun build(): ConnectivityAndInternetAccess = ConnectivityAndInternetAccess(
+            normalizeHosts(hosts),
+            normalizeDnsResolvers(dnsResolvers),
+            dnsStrategy,
+            httpStrategy
+        )
+    }
+
+    // Instance API: preferred for new code.
+    fun checkInternetAsync(
+        context: Context,
+        callback: InternetCallback
+    ): Request = executeAsync(
+        context,
+        instanceResolvers,
+        instanceHosts,
+        instanceDnsStrategy,
+        instanceHttpStrategy,
+        callback
+    )
+
+    fun checkInternetBlocking(context: Context): InternetResult = executeBlocking(
+        context,
+        instanceResolvers,
+        instanceHosts,
+        instanceDnsStrategy,
+        instanceHttpStrategy
+    )
+
+    companion object {
+        private const val MINIMUM_FAST_KBPS = 3_072
+        private const val CONNECT_TIMEOUT_MS = 800
+        private const val READ_TIMEOUT_MS = 800
+        private const val DNS_TIMEOUT_MS = 650
+        private const val EFFECTIVE_DNS_STAGE_TIMEOUT_MS = 350L
+        private const val DNS_STAGE_TIMEOUT_MS = 700L
+        private const val TOTAL_PROBE_TIMEOUT_MS = 2_000L
+        private const val MAX_PARALLEL_PROBES = 9
+        private const val DNS_PORT = 53
+        private const val CONNECTION_ATTEMPT_TIMEOUT_MS = 30_000L
+        private const val DNS_QUERY_NAME = "example.com"
+
+        private val DEFAULT_DNS_RESOLVERS = listOf(
+            "1.1.1.1",
+            "8.8.8.8",
+            "9.9.9.9",
+            "208.67.222.222"
+        )
+
+        private val DEFAULT_HOSTS = listOf(
+            "https://www.google.com/generate_204",
+            "https://www.facebook.com/",
+            "https://www.wolframalpha.com/",
+            "https://www.apple.com/",
+            "https://www.amazon.com/"
+        )
+
+        @Volatile
+        private var globalHosts: List<String> = DEFAULT_HOSTS
+
+        @Volatile
+        private var globalResolvers: List<String> = DEFAULT_DNS_RESOLVERS
+
+        @Volatile
+        private var globalDnsStrategy: DnsProbeStrategy = DefaultDnsProbe()
+
+        @Volatile
+        private var globalHttpStrategy: HttpProbeStrategy = DefaultHttpProbe()
+
+        private val connectionAttemptLock = Any()
+        private val connectionAttemptQueue = ArrayDeque<ConnectionAttempt>()
+        private val connectionAttempts = AtomicInteger(0)
+        private val dnsTransactionId = AtomicInteger(System.nanoTime().toInt())
+        private val probeThreadNumber = AtomicInteger(0)
+
+        private val mainHandler = Handler(Looper.getMainLooper())
+        private val tls12SocketFactory: SSLSocketFactory? = createTls12Factory()
+
+        private val executor = Executors.newCachedThreadPool(object : ThreadFactory {
+            private var number = 0
+
+            @Synchronized
+            override fun newThread(runnable: Runnable): Thread =
+                Thread(runnable, "connectivity-check-${++number}").apply {
+                    isDaemon = true
+                }
+        })
+
+        @JvmStatic
+        fun strictCaptivePortalBuilder(): Builder = Builder()
+            .setDnsResolvers(emptyList())
+            .setHosts(listOf("https://connectivitycheck.gstatic.com/generate_204"))
+            .setHttpProbeStrategy(StrictHttpProbe())
+
+        @JvmStatic
+        fun isActiveNetworkConnected(context: Context): Boolean = isConnected(context)
+
+        @JvmStatic
+        fun isConnected(context: Context, network: Network?): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                return isConnected(context)
+            }
+            if (network == null) {
+                return false
+            }
+            return manager(context).getNetworkCapabilities(network).isUsable()
+        }
+
+        @JvmStatic
+        fun isConnecting(context: Context?): Boolean {
+            context ?: throw IllegalArgumentException("context == null")
+
+            if (isConnected(context)) {
+                return false
+            }
+
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+                if (legacyNetworks(manager(context)).any { info ->
+                        info != null &&
+                            info.isAvailable &&
+                            info.state == NetworkInfo.State.CONNECTING
+                    }
+                ) {
+                    return true
+                }
+            }
+
+            return connectionAttempts.get() > 0
+        }
+
+        @JvmStatic
+        fun beginConnectionAttempt(context: Context) {
+            // Keep the context parameter for API compatibility and its non-null contract.
+            context.applicationContext
+
+            val attempt = ConnectionAttempt()
+            synchronized(connectionAttemptLock) {
+                connectionAttemptQueue.addLast(attempt)
+                connectionAttempts.incrementAndGet()
+            }
+
+            mainHandler.postDelayed(
+                { closeConnectionAttempt(attempt) },
+                CONNECTION_ATTEMPT_TIMEOUT_MS
+            )
+        }
+
+        @JvmStatic
+        fun endConnectionAttempt() {
+            synchronized(connectionAttemptLock) {
+                while (connectionAttemptQueue.isNotEmpty()) {
+                    val attempt = connectionAttemptQueue.removeFirst()
+                    if (!attempt.closed) {
+                        attempt.closed = true
+                        connectionAttempts.updateAndGet { value ->
+                            if (value > 0) value - 1 else 0
+                        }
+                        return
+                    }
+                }
+            }
+        }
+
+        @JvmStatic
+        fun isConnectedOrConnecting(context: Context?): Boolean {
+            context ?: throw IllegalArgumentException("context == null")
+
+            if (isConnected(context)) {
+                return true
+            }
+
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+                if (legacyNetworks(manager(context)).any { info ->
+                        info != null &&
+                            info.isAvailable &&
+                            info.isConnectedOrConnecting
+                    }
+                ) {
+                    return true
+                }
+            }
+
+            return connectionAttempts.get() > 0
+        }
+
+        @JvmStatic
+        fun isConnected(context: Context?): Boolean {
+            context ?: throw IllegalArgumentException("context == null")
+            val connectivityManager = manager(context)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                val active = connectivityManager.activeNetwork
+                if (active != null &&
+                    connectivityManager.getNetworkCapabilities(active).isUsable()
+                ) {
+                    clearConnectionAttempts()
+                    return true
+                }
+                return false
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                if (connectivityManager.allNetworks.any { network ->
+                        connectivityManager.getNetworkCapabilities(network).isUsable()
+                    }
+                ) {
+                    clearConnectionAttempts()
+                    return true
+                }
+                return false
+            }
+
+            val connected = connectivityManager.activeNetworkInfo.isConnectedLegacy()
+            if (connected) {
+                clearConnectionAttempts()
+            }
+            return connected
+        }
+
+        /** Cheap point-in-time snapshot of the application's default network. */
+        @JvmStatic
+        fun snapshotNetworkState(context: Context): NetworkState {
+            val connectivityManager = manager(context)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                val active = connectivityManager.activeNetwork ?: return disconnectedNetworkState()
+                return networkStateFromCapabilities(
+                    connectivityManager.getNetworkCapabilities(active)
+                )
+            }
+
+            val connected = connectivityManager.activeNetworkInfo.isConnectedLegacy()
+            return NetworkState(
+                connected = connected,
+                internetValidated = false,
+                captivePortalDetected = false,
+                observedAtElapsedRealtime = SystemClock.elapsedRealtime()
+            )
+        }
+
+        /**
+         * Starts passive default-network observation and immediately posts the current
+         * state to the main thread. Close the returned observer when no longer needed.
+         */
+        @JvmStatic
+        fun observeNetwork(
+            context: Context,
+            callback: NetworkStateCallback
+        ): NetworkObserver = NetworkObserver(context, callback)
+
+        /**
+         * Returns whether Android most recently validated general Internet access on the
+         * application's current default network. This is a system snapshot, not a fresh
+         * reachability probe. API levels below 23 do not expose VALIDATED and return false.
+         */
+        @JvmStatic
+        fun isInternetValidated(context: Context): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                return false
+            }
+
+            val connectivityManager = manager(context)
+            val active = connectivityManager.activeNetwork ?: return false
+            return isInternetValidated(context, active)
+        }
+
+        /** Network-specific variant of [isInternetValidated]. */
+        @JvmStatic
+        fun isInternetValidated(context: Context, network: Network?): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || network == null) {
+                return false
+            }
+
+            val capabilities = manager(context).getNetworkCapabilities(network)
+            return capabilities != null &&
+                capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+                capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        }
+
+        /**
+         * Returns whether Android detected a captive portal on the application's current
+         * default network the last time that network was probed. API levels below 23 do not
+         * expose CAPTIVE_PORTAL and return false.
+         */
+        @JvmStatic
+        fun isCaptivePortalDetected(context: Context): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                return false
+            }
+
+            val connectivityManager = manager(context)
+            val active = connectivityManager.activeNetwork ?: return false
+            return isCaptivePortalDetected(context, active)
+        }
+
+        /** Network-specific variant of [isCaptivePortalDetected]. */
+        @JvmStatic
+        fun isCaptivePortalDetected(context: Context, network: Network?): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || network == null) {
+                return false
+            }
+
+            val capabilities = manager(context).getNetworkCapabilities(network)
+            return capabilities?.hasCapability(
+                NetworkCapabilities.NET_CAPABILITY_CAPTIVE_PORTAL
+            ) == true
+        }
+
+        @JvmStatic
+        fun isConnectedWifi(context: Context?): Boolean =
+            hasTransport(context, NetworkCapabilities.TRANSPORT_WIFI)
+
+        @JvmStatic
+        fun isConnectedWifi(context: Context, network: Network?): Boolean =
+            hasTransport(context, network, NetworkCapabilities.TRANSPORT_WIFI)
+
+        @JvmStatic
+        fun isConnectedWifiOverAirplaneMode(context: Context): Boolean =
+            isAirplaneModeOn(context) && isConnectedWifi(context)
+
+        @JvmStatic
+        fun isConnectedWifiOverAirplaneMode(
+            context: Context,
+            network: Network?
+        ): Boolean = isAirplaneModeOn(context) && isConnectedWifi(context, network)
+
+        @JvmStatic
+        fun isConnectedMobileTelephonyManager(context: Context): Boolean {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                return isConnectedMobile(context)
+            }
+
+            return try {
+                val telephonyManager =
+                    context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+                telephonyManager?.dataState == TelephonyManager.DATA_CONNECTED
+            } catch (_: SecurityException) {
+                isConnectedMobile(context)
+            }
+        }
+
+        @JvmStatic
+        fun isConnectedMobile(context: Context, network: Network?): Boolean =
+            hasTransport(context, network, NetworkCapabilities.TRANSPORT_CELLULAR)
+
+        @JvmStatic
+        fun isConnectedMobile(context: Context?): Boolean =
+            hasTransport(context, NetworkCapabilities.TRANSPORT_CELLULAR)
+
+        @JvmStatic
+        fun isConnectedEthernet(context: Context?): Boolean =
+            hasTransport(context, NetworkCapabilities.TRANSPORT_ETHERNET)
+
+        @JvmStatic
+        fun isConnectedEthernet(context: Context, network: Network?): Boolean =
+            hasTransport(context, network, NetworkCapabilities.TRANSPORT_ETHERNET)
+
+        @JvmStatic
+        fun isConnectedFast(context: Context): Boolean {
+            val connectivityManager = manager(context)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                return connectivityManager.allNetworks.any { network ->
+                    isFast(connectivityManager.getNetworkCapabilities(network))
+                }
+            }
+
+            return legacyNetworks(connectivityManager).any { info ->
+                info != null &&
+                    info.isConnectedLegacy() &&
+                    isConnectionFast(info.type, info.subtype)
+            }
+        }
+
+        @JvmStatic
+        fun isConnectedFast(context: Context, network: Network?): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                val info = manager(context).activeNetworkInfo
+                return info != null &&
+                    info.isConnectedLegacy() &&
+                    isConnectionFast(info.type, info.subtype)
+            }
+
+            if (network == null) {
+                return false
+            }
+
+            return isFast(manager(context).getNetworkCapabilities(network))
+        }
+
+        @JvmStatic
+        fun isAirplaneModeOn(context: Context): Boolean =
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                Settings.System.getInt(
+                    context.contentResolver,
+                    Settings.System.AIRPLANE_MODE_ON,
+                    0
+                ) != 0
+            } else {
+                Settings.Global.getInt(
+                    context.contentResolver,
+                    Settings.Global.AIRPLANE_MODE_ON,
+                    0
+                ) != 0
+            }
+
+        @JvmStatic
+        fun vpnActive(context: Context): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                return false
+            }
+
+            val connectivityManager = manager(context)
+            return connectivityManager.allNetworks.any { network ->
+                connectivityManager.getNetworkCapabilities(network)
+                    ?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
+            }
+        }
+
+        // Static compatibility helpers. Names intentionally differ from the instance
+        // methods to avoid duplicate JVM signatures.
+        @JvmStatic
+        fun isInternetReachable(context: Context?): Boolean {
+            context ?: throw IllegalArgumentException("context == null")
+            return executeBlocking(
+                context,
+                globalResolvers,
+                globalHosts,
+                globalDnsStrategy,
+                globalHttpStrategy
+            ).reachable
+        }
+
+        @JvmStatic
+        fun isInternetReachable(
+            context: Context?,
+            hosts: ArrayList<String>
+        ): Boolean {
+            context ?: throw IllegalArgumentException("context == null")
+            return executeBlocking(
+                context,
+                globalResolvers,
+                normalizeHosts(hosts),
+                globalDnsStrategy,
+                globalHttpStrategy
+            ).reachable
+        }
+
+        @JvmStatic
+        fun checkInternetAsyncDefault(
+            context: Context,
+            callback: InternetCallback
+        ): Request = executeAsync(
+            context,
+            globalResolvers,
+            globalHosts,
+            globalDnsStrategy,
+            globalHttpStrategy,
+            callback
+        )
+
+        @JvmStatic
+        fun checkInternetAsyncDefault(
+            context: Context,
+            hosts: List<String>,
+            callback: InternetCallback
+        ): Request = executeAsync(
+            context,
+            globalResolvers,
+            hosts,
+            globalDnsStrategy,
+            globalHttpStrategy,
+            callback
+        )
+
+        @JvmStatic
+        fun checkInternetAsyncDefault(
+            context: Context,
+            dnsResolvers: List<String>,
+            hosts: List<String>,
+            callback: InternetCallback
+        ): Request = executeAsync(
+            context,
+            dnsResolvers,
+            hosts,
+            globalDnsStrategy,
+            globalHttpStrategy,
+            callback
+        )
+
+        @JvmStatic
+        fun checkInternetBlockingDefault(
+            context: Context
+        ): InternetResult = executeBlocking(
+            context,
+            globalResolvers,
+            globalHosts,
+            globalDnsStrategy,
+            globalHttpStrategy
+        )
+
+        @JvmStatic
+        fun checkInternetBlockingDefault(
+            context: Context,
+            hosts: List<String>
+        ): InternetResult = executeBlocking(
+            context,
+            globalResolvers,
+            hosts,
+            globalDnsStrategy,
+            globalHttpStrategy
+        )
+
+        @JvmStatic
+        fun checkInternetBlockingDefault(
+            context: Context,
+            dnsResolvers: List<String>,
+            hosts: List<String>
+        ): InternetResult = executeBlocking(
+            context,
+            dnsResolvers,
+            hosts,
+            globalDnsStrategy,
+            globalHttpStrategy
+        )
+
+        @JvmStatic
+        fun defaultHosts(): List<String> = DEFAULT_HOSTS
+
+        @JvmStatic
+        fun defaultDnsResolvers(): List<String> = DEFAULT_DNS_RESOLVERS
+
+        private fun executeAsync(
+            context: Context,
+            dnsResolvers: List<String>,
+            hosts: List<String>,
+            dnsStrategy: DnsProbeStrategy,
+            httpStrategy: HttpProbeStrategy,
+            callback: InternetCallback
+        ): Request {
+            val appContext = context.applicationContext ?: context
+            val normalizedResolvers = normalizeDnsResolvers(dnsResolvers)
+            val normalizedHosts = normalizeHosts(hosts)
+            val request = Request()
+
+            request.attach(
+                executor.submit {
+                    val result = executeBlocking(
+                        appContext,
+                        normalizedResolvers,
+                        normalizedHosts,
+                        dnsStrategy,
+                        httpStrategy
+                    )
+
+                    if (!request.isCancelled()) {
+                        mainHandler.post {
+                            if (!request.isCancelled()) {
+                                callback.onResult(result)
+                            }
+                        }
+                    }
+                }
+            )
+
+            return request
+        }
+
+        private fun executeBlocking(
+            context: Context,
+            dnsResolvers: List<String>,
+            hosts: List<String>,
+            dnsStrategy: DnsProbeStrategy,
+            httpStrategy: HttpProbeStrategy
+        ): InternetResult {
+            val started = SystemClock.elapsedRealtime()
+            val deadline = started + TOTAL_PROBE_TIMEOUT_MS
+            val attempted = CopyOnWriteArrayList<String>()
+            val connectivityManager = manager(context)
+            val network = selectProbeNetwork(connectivityManager)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                if (network == null) {
+                    return InternetResult(
+                        false,
+                        null,
+                        attempted.toList(),
+                        SystemClock.elapsedRealtime() - started
+                    )
+                }
+            } else if (!isConnected(context)) {
+                return InternetResult(
+                    false,
+                    null,
+                    attempted.toList(),
+                    SystemClock.elapsedRealtime() - started
+                )
+            }
+
+            val probeExecutor = newProbeExecutor()
+            try {
+                val normalizedResolvers = normalizeDnsResolvers(dnsResolvers)
+                var reached: String?
+
+                /*
+                 * Prefer DNS configured for the selected Android Network before direct
+                 * public resolvers. This respects VPN and Private DNS routing. An empty
+                 * resolver list disables the entire DNS stage; a custom strategy owns it.
+                 */
+                if (normalizedResolvers.isNotEmpty() && dnsStrategy is DefaultDnsProbe) {
+                    reached = raceProbes(
+                        listOf(
+                            ProbeAttempt(effectiveDnsLabel()) {
+                                checkEffectiveDns(network)
+                            }
+                        ),
+                        attempted,
+                        minOf(deadline, started + EFFECTIVE_DNS_STAGE_TIMEOUT_MS),
+                        probeExecutor
+                    )
+
+                    if (reached != null) {
+                        return InternetResult(
+                            true,
+                            reached,
+                            attempted.toList(),
+                            SystemClock.elapsedRealtime() - started
+                        )
+                    }
+                }
+
+                val dnsAttempts = normalizedResolvers.map { resolver ->
+                    ProbeAttempt(dnsEndpointLabel(resolver)) {
+                        dnsStrategy.checkDns(resolver, network)
+                    }
+                }
+
+                reached = raceProbes(
+                    dnsAttempts,
+                    attempted,
+                    minOf(deadline, started + DNS_STAGE_TIMEOUT_MS),
+                    probeExecutor
+                )
+
+                if (reached != null) {
+                    return InternetResult(
+                        true,
+                        reached,
+                        attempted.toList(),
+                        SystemClock.elapsedRealtime() - started
+                    )
+                }
+
+                val hostAttempts = normalizeHosts(hosts).map { host ->
+                    ProbeAttempt(host) {
+                        httpStrategy.checkHttp(host, network)
+                    }
+                }
+
+                reached = raceProbes(
+                    hostAttempts,
+                    attempted,
+                    deadline,
+                    probeExecutor
+                )
+
+                if (reached != null) {
+                    return InternetResult(
+                        true,
+                        reached,
+                        attempted.toList(),
+                        SystemClock.elapsedRealtime() - started
+                    )
+                }
+
+                return InternetResult(
+                    false,
+                    null,
+                    attempted.toList(),
+                    SystemClock.elapsedRealtime() - started
+                )
+            } finally {
+                probeExecutor.shutdownNow()
+            }
+        }
+
+        private fun raceProbes(
+            probes: List<ProbeAttempt>,
+            attempted: MutableList<String>,
+            deadline: Long,
+            probeExecutor: ExecutorService
+        ): String? {
+            if (probes.isEmpty() || Thread.currentThread().isInterrupted) {
+                return null
+            }
+
+            val completion = ExecutorCompletionService<String?>(probeExecutor)
+            val futures = probes.map { probe ->
+                completion.submit(
+                    Callable {
+                        attempted += probe.label
+                        if (Thread.currentThread().isInterrupted) {
+                            null
+                        } else if (probe.operation()) {
+                            probe.label
+                        } else {
+                            null
+                        }
+                    }
+                )
+            }
+
+            var remaining = futures.size
+            try {
+                while (remaining-- > 0) {
+                    val wait = deadline - SystemClock.elapsedRealtime()
+                    if (wait <= 0) {
+                        return null
+                    }
+
+                    val completed = completion.poll(wait, TimeUnit.MILLISECONDS) ?: return null
+
+                    try {
+                        completed.get()?.let { return it }
+                    } catch (_: CancellationException) {
+                        // A failed probe does not fail the whole stage.
+                    } catch (_: ExecutionException) {
+                        // A failed probe does not fail the whole stage.
+                    }
+                }
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+            } finally {
+                futures.forEach { it.cancel(true) }
+            }
+
+            return null
+        }
+
+        private fun checkEffectiveDns(network: Network?): Boolean =
+            try {
+                val addresses = if (
+                    network != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                ) {
+                    network.getAllByName(DNS_QUERY_NAME)
+                } else {
+                    InetAddress.getAllByName(DNS_QUERY_NAME)
+                }
+                addresses.isNotEmpty()
+            } catch (_: IOException) {
+                false
+            } catch (_: RuntimeException) {
+                false
+            }
+
+        private fun effectiveDnsLabel(): String = "dns://system/$DNS_QUERY_NAME"
+
+        class DefaultDnsProbe : DnsProbeStrategy {
+            override fun checkDns(resolver: String, network: Network?): Boolean {
+                val endpoint = parseDnsResolver(resolver)
+                var socket: DatagramSocket? = null
+
+                return try {
+                    val transactionId = dnsTransactionId.incrementAndGet() and 0xffff
+                    val query = createDnsQuery(transactionId)
+
+                    socket = DatagramSocket()
+                    if (
+                        network != null &&
+                        Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
+                    ) {
+                        network.bindSocket(socket)
+                    }
+
+                    socket.soTimeout = DNS_TIMEOUT_MS
+                    socket.connect(InetSocketAddress(endpoint.host, endpoint.port))
+                    socket.send(DatagramPacket(query, query.size))
+
+                    val buffer = ByteArray(512)
+                    val response = DatagramPacket(buffer, buffer.size)
+                    socket.receive(response)
+
+                    isValidDnsResponse(transactionId, response.data, response.length)
+                } catch (_: IOException) {
+                    false
+                } catch (_: RuntimeException) {
+                    false
+                } finally {
+                    socket?.close()
+                }
+            }
+
+            private fun createDnsQuery(transactionId: Int): ByteArray {
+                val labels = DNS_QUERY_NAME.split(".")
+                var length = 12 + 1 + 4
+                labels.forEach { label ->
+                    length += 1 + label.length
+                }
+
+                val query = ByteArray(length)
+                query[0] = (transactionId ushr 8).toByte()
+                query[1] = transactionId.toByte()
+                query[2] = 0x01
+                query[5] = 0x01
+
+                var offset = 12
+                for (label in labels) {
+                    query[offset++] = label.length.toByte()
+                    for (character in label) {
+                        query[offset++] = character.code.toByte()
+                    }
+                }
+
+                query[offset++] = 0x00
+                query[offset++] = 0x00
+                query[offset++] = 0x01
+                query[offset++] = 0x00
+                query[offset] = 0x01
+                return query
+            }
+
+            private fun isValidDnsResponse(
+                transactionId: Int,
+                response: ByteArray?,
+                length: Int
+            ): Boolean {
+                if (response == null || length < 12) {
+                    return false
+                }
+
+                val responseId =
+                    ((response[0].toInt() and 0xff) shl 8) or
+                        (response[1].toInt() and 0xff)
+                val flags =
+                    ((response[2].toInt() and 0xff) shl 8) or
+                        (response[3].toInt() and 0xff)
+                val questionCount =
+                    ((response[4].toInt() and 0xff) shl 8) or
+                        (response[5].toInt() and 0xff)
+                val responseCode = flags and 0x000f
+
+                return responseId == transactionId &&
+                    (flags and 0x8000) != 0 &&
+                    (flags and 0x7800) == 0 &&
+                    questionCount > 0 &&
+                    responseCode <= 5
+            }
+        }
+
+        class DefaultHttpProbe : HttpProbeStrategy {
+            override fun checkHttp(address: String, network: Network?): Boolean {
+                var connection: HttpURLConnection? = null
+
+                return try {
+                    val url = URL(address)
+                    val raw: URLConnection =
+                        if (
+                            network != null &&
+                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                        ) {
+                            network.openConnection(url)
+                        } else {
+                            url.openConnection()
+                        }
+
+                    connection = raw as HttpURLConnection
+                    configureTlsIfNecessary(connection)
+
+                    connection.requestMethod = "GET"
+                    connection.instanceFollowRedirects = false
+                    connection.connectTimeout = CONNECT_TIMEOUT_MS
+                    connection.readTimeout = READ_TIMEOUT_MS
+                    connection.useCaches = false
+                    connection.setRequestProperty("Accept", "*/*")
+                    connection.setRequestProperty("Accept-Encoding", "identity")
+                    connection.setRequestProperty("Connection", "close")
+                    connection.setRequestProperty(
+                        "User-Agent",
+                        "ConnectivityAndInternetAccess/5"
+                    )
+
+                    connection.responseCode in 100..599
+                } catch (_: IOException) {
+                    false
+                } catch (_: RuntimeException) {
+                    false
+                } finally {
+                    connection?.disconnect()
+                }
+            }
+        }
+
+        class StrictHttpProbe : HttpProbeStrategy {
+            override fun checkHttp(address: String, network: Network?): Boolean {
+                var connection: HttpURLConnection? = null
+
+                return try {
+                    val url = URL(address)
+                    val raw: URLConnection =
+                        if (
+                            network != null &&
+                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                        ) {
+                            network.openConnection(url)
+                        } else {
+                            url.openConnection()
+                        }
+
+                    connection = raw as HttpURLConnection
+                    configureTlsIfNecessary(connection)
+
+                    connection.requestMethod = "GET"
+                    connection.instanceFollowRedirects = false
+                    connection.connectTimeout = CONNECT_TIMEOUT_MS
+                    connection.readTimeout = READ_TIMEOUT_MS
+                    connection.useCaches = false
+                    connection.setRequestProperty("Accept", "*/*")
+                    connection.setRequestProperty("Accept-Encoding", "identity")
+                    connection.setRequestProperty("Connection", "close")
+                    connection.setRequestProperty(
+                        "User-Agent",
+                        "ConnectivityAndInternetAccess/5"
+                    )
+
+                    val response = connection.responseCode
+                    if (address.contains("generate_204")) {
+                        response == HttpURLConnection.HTTP_NO_CONTENT
+                    } else {
+                        response == HttpURLConnection.HTTP_OK ||
+                            response == HttpURLConnection.HTTP_NO_CONTENT
+                    }
+                } catch (_: IOException) {
+                    false
+                } catch (_: RuntimeException) {
+                    false
+                } finally {
+                    connection?.disconnect()
+                }
+            }
+        }
+
+        private fun configureTlsIfNecessary(connection: HttpURLConnection) {
+            if (
+                connection is HttpsURLConnection &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN &&
+                Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP
+            ) {
+                tls12SocketFactory?.let { factory ->
+                    connection.sslSocketFactory = factory
+                }
+            }
+        }
+
+        private fun networkStateFromCapabilities(
+            capabilities: NetworkCapabilities?
+        ): NetworkState {
+            val connected = capabilities.isUsable()
+            val validated = connected &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                capabilities?.hasCapability(
+                    NetworkCapabilities.NET_CAPABILITY_VALIDATED
+                ) == true
+            val captivePortal = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                capabilities?.hasCapability(
+                    NetworkCapabilities.NET_CAPABILITY_CAPTIVE_PORTAL
+                ) == true
+            return NetworkState(
+                connected = connected,
+                internetValidated = validated,
+                captivePortalDetected = captivePortal,
+                observedAtElapsedRealtime = SystemClock.elapsedRealtime()
+            )
+        }
+
+        private fun disconnectedNetworkState(): NetworkState = NetworkState(
+            connected = false,
+            internetValidated = false,
+            captivePortalDetected = false,
+            observedAtElapsedRealtime = SystemClock.elapsedRealtime()
+        )
+
+        private fun manager(context: Context): ConnectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+                ?: throw IllegalStateException("ConnectivityManager unavailable")
+
+        private fun NetworkCapabilities?.isUsable(): Boolean {
+            if (
+                this == null ||
+                !hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            ) {
+                return false
+            }
+
+            return Build.VERSION.SDK_INT < Build.VERSION_CODES.P ||
+                hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED)
+        }
+
+        private fun hasTransport(context: Context?, transport: Int): Boolean {
+            context ?: throw IllegalArgumentException("context == null")
+            val connectivityManager = manager(context)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                return connectivityManager.allNetworks.any { network ->
+                    val capabilities = connectivityManager.getNetworkCapabilities(network)
+                    capabilities.isUsable() &&
+                        capabilities?.hasTransport(transport) == true
+                }
+            }
+
+            return legacyNetworks(connectivityManager).any { info ->
+                info != null &&
+                    info.isConnectedLegacy() &&
+                    legacyTypeMatches(info.type, transport)
+            }
+        }
+
+        private fun hasTransport(
+            context: Context,
+            network: Network?,
+            transport: Int
+        ): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                return hasTransport(context, transport)
+            }
+
+            if (network == null) {
+                return false
+            }
+
+            val capabilities = manager(context).getNetworkCapabilities(network)
+            return capabilities.isUsable() &&
+                capabilities?.hasTransport(transport) == true
+        }
+
+        private fun legacyTypeMatches(type: Int, transport: Int): Boolean =
+            when (transport) {
+                NetworkCapabilities.TRANSPORT_WIFI ->
+                    type == ConnectivityManager.TYPE_WIFI
+
+                NetworkCapabilities.TRANSPORT_CELLULAR ->
+                    type == ConnectivityManager.TYPE_MOBILE
+
+                NetworkCapabilities.TRANSPORT_ETHERNET ->
+                    type == ConnectivityManager.TYPE_ETHERNET
+
+                else -> false
+            }
+
+        private fun isFast(capabilities: NetworkCapabilities?): Boolean =
+            capabilities.isUsable() &&
+                capabilities!!.linkDownstreamBandwidthKbps >= MINIMUM_FAST_KBPS &&
+                capabilities.linkUpstreamBandwidthKbps >= MINIMUM_FAST_KBPS
+
+        private fun legacyNetworks(
+            connectivityManager: ConnectivityManager
+        ): Array<NetworkInfo?> = connectivityManager.allNetworkInfo ?: emptyArray()
+
+        private fun NetworkInfo?.isConnectedLegacy(): Boolean =
+            this != null && isAvailable && isConnected
+
+        private fun isConnectionFast(type: Int, subType: Int): Boolean {
+            if (
+                type == ConnectivityManager.TYPE_WIFI ||
+                type == ConnectivityManager.TYPE_ETHERNET
+            ) {
+                return true
+            }
+
+            if (type != ConnectivityManager.TYPE_MOBILE) {
+                return false
+            }
+
+            return when (subType) {
+                TelephonyManager.NETWORK_TYPE_EVDO_0,
+                TelephonyManager.NETWORK_TYPE_EVDO_A,
+                TelephonyManager.NETWORK_TYPE_HSDPA,
+                TelephonyManager.NETWORK_TYPE_HSPA,
+                TelephonyManager.NETWORK_TYPE_HSUPA,
+                TelephonyManager.NETWORK_TYPE_UMTS,
+                TelephonyManager.NETWORK_TYPE_EHRPD,
+                TelephonyManager.NETWORK_TYPE_EVDO_B,
+                TelephonyManager.NETWORK_TYPE_HSPAP,
+                TelephonyManager.NETWORK_TYPE_LTE -> true
+
+                else -> false
+            }
+        }
+
+        private fun selectProbeNetwork(
+            connectivityManager: ConnectivityManager
+        ): Network? {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                return null
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                val active = connectivityManager.activeNetwork
+                if (
+                    active != null &&
+                    connectivityManager.getNetworkCapabilities(active).isUsable()
+                ) {
+                    return active
+                }
+                return null
+            }
+
+            return connectivityManager.allNetworks.firstOrNull { network ->
+                connectivityManager.getNetworkCapabilities(network).isUsable()
+            }
+        }
+
+        private fun normalizeHosts(hosts: List<String>): List<String> {
+            val normalized = LinkedHashSet<String>()
+
+            for (raw in hosts) {
+                val trimmed = raw.trim()
+                if (trimmed.isEmpty()) {
+                    continue
+                }
+
+                val value =
+                    if (
+                        trimmed.startsWith("https://", ignoreCase = true) ||
+                        trimmed.startsWith("http://", ignoreCase = true)
+                    ) {
+                        trimmed
+                    } else {
+                        "https://$trimmed/"
+                    }
+
+                require(isValidURL(value)) {
+                    "Invalid HTTP(S) URL: $value"
+                }
+                normalized += value
+            }
+
+            require(normalized.isNotEmpty()) {
+                "hosts cannot be empty"
+            }
+
+            return normalized.toList()
+        }
+
+        private fun normalizeDnsResolvers(resolvers: List<String>): List<String> {
+            val normalized = LinkedHashSet<String>()
+
+            for (raw in resolvers) {
+                val value = raw.trim()
+                if (value.isNotEmpty()) {
+                    parseDnsResolver(value)
+                    normalized += value
+                }
+            }
+
+            return normalized.toList()
+        }
+
+        private fun isValidURL(address: String?): Boolean {
+            address ?: throw IllegalArgumentException("url == null")
+
+            return try {
+                val parsed = URL(address)
+                parsed.toURI()
+                (parsed.protocol.equals("http", ignoreCase = true) ||
+                    parsed.protocol.equals("https", ignoreCase = true)) &&
+                    parsed.host.isNotEmpty()
+            } catch (_: Exception) {
+                false
+            }
+        }
+
+        private fun dnsEndpointLabel(resolver: String): String {
+            val endpoint = parseDnsResolver(resolver)
+            val host = if (':' in endpoint.host) {
+                "[${endpoint.host}]"
+            } else {
+                endpoint.host
+            }
+            return "dns://$host:${endpoint.port}"
+        }
+
+        private fun parseDnsResolver(resolver: String): DnsResolver {
+            val value = resolver.trim()
+            require(value.isNotEmpty()) {
+                "Invalid DNS resolver"
+            }
+
+            val host: String
+            var port = DNS_PORT
+
+            if (value.startsWith("[")) {
+                val closingBracket = value.indexOf(']')
+                require(closingBracket > 1) {
+                    "Invalid DNS resolver"
+                }
+
+                host = value.substring(1, closingBracket).trim()
+                val remainder = value.substring(closingBracket + 1).trim()
+                if (remainder.isNotEmpty()) {
+                    require(remainder.startsWith(":")) {
+                        "Invalid DNS resolver"
+                    }
+                    port = parsePort(remainder.substring(1))
+                }
+            } else {
+                val firstColon = value.indexOf(':')
+                val lastColon = value.lastIndexOf(':')
+
+                if (firstColon > 0 && firstColon == lastColon) {
+                    host = value.substring(0, firstColon).trim()
+                    port = parsePort(value.substring(firstColon + 1))
+                } else {
+                    host = value
+                }
+            }
+
+            require(host.isNotEmpty() && port in 1..65_535) {
+                "Invalid DNS resolver"
+            }
+
+            return DnsResolver(host, port)
+        }
+
+        private fun parsePort(rawPort: String): Int {
+            val port = rawPort.trim().toIntOrNull()
+                ?: throw IllegalArgumentException("Invalid DNS resolver port")
+            require(port in 1..65_535) {
+                "Invalid DNS resolver port"
+            }
+            return port
+        }
+
+        private fun newProbeExecutor(): ExecutorService =
+            Executors.newFixedThreadPool(
+                MAX_PARALLEL_PROBES,
+                ThreadFactory { runnable ->
+                    Thread(
+                        runnable,
+                        "connectivity-probe-${probeThreadNumber.incrementAndGet()}"
+                    ).apply {
+                        isDaemon = true
+                    }
+                }
+            )
+
+        private fun closeConnectionAttempt(attempt: ConnectionAttempt): Boolean {
+            synchronized(connectionAttemptLock) {
+                if (attempt.closed) {
+                    return false
+                }
+
+                attempt.closed = true
+                connectionAttemptQueue.remove(attempt)
+                connectionAttempts.updateAndGet { value ->
+                    if (value > 0) value - 1 else 0
+                }
+                return true
+            }
+        }
+
+        private fun clearConnectionAttempts() {
+            synchronized(connectionAttemptLock) {
+                connectionAttemptQueue.forEach { attempt ->
+                    attempt.closed = true
+                }
+                connectionAttemptQueue.clear()
+                connectionAttempts.set(0)
+            }
+        }
+
+        private data class ProbeAttempt(
+            val label: String,
+            val operation: () -> Boolean
+        )
+
+        private data class DnsResolver(
+            val host: String,
+            val port: Int
+        )
+
+        private class ConnectionAttempt {
+            var closed: Boolean = false
+        }
+
+        private fun createTls12Factory(): SSLSocketFactory? {
+            if (
+                Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN ||
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+            ) {
+                return null
+            }
+
+            return try {
+                val context = SSLContext.getInstance("TLSv1.2")
+                context.init(null, null, null)
+                Tls12SocketFactory(context.socketFactory)
+            } catch (_: GeneralSecurityException) {
+                null
+            }
+        }
+
+        private class Tls12SocketFactory(
+            private val delegate: SSLSocketFactory
+        ) : SSLSocketFactory() {
+
+            override fun getDefaultCipherSuites(): Array<String> =
+                delegate.defaultCipherSuites
+
+            override fun getSupportedCipherSuites(): Array<String> =
+                delegate.supportedCipherSuites
+
+            override fun createSocket(
+                socket: Socket,
+                host: String,
+                port: Int,
+                autoClose: Boolean
+            ): Socket = enable(delegate.createSocket(socket, host, port, autoClose))
+
+            override fun createSocket(host: String, port: Int): Socket =
+                enable(delegate.createSocket(host, port))
+
+            override fun createSocket(
+                host: String,
+                port: Int,
+                localHost: InetAddress,
+                localPort: Int
+            ): Socket = enable(delegate.createSocket(host, port, localHost, localPort))
+
+            override fun createSocket(host: InetAddress, port: Int): Socket =
+                enable(delegate.createSocket(host, port))
+
+            override fun createSocket(
+                address: InetAddress,
+                port: Int,
+                localAddress: InetAddress,
+                localPort: Int
+            ): Socket = enable(
+                delegate.createSocket(address, port, localAddress, localPort)
+            )
+
+            private fun enable(socket: Socket): Socket {
+                if (
+                    socket is SSLSocket &&
+                    socket.supportedProtocols.contains("TLSv1.2")
+                ) {
+                    socket.enabledProtocols = arrayOf("TLSv1.2")
+                }
+                return socket
+            }
+        }
+    }
+}

--- a/shared/network/src/androidMain/kotlin/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt
+++ b/shared/network/src/androidMain/kotlin/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt
@@ -2,12 +2,8 @@
  * SPDX-License-Identifier: MIT
  *
  * Based on Connectivity.java by Emil Davtyan (emil2k), later modified by str4d.
- * Further modernized by Rodrigo Sambade Saá for thread-safety, Android API
- * compatibility, extensible probe strategies, captive-portal-aware reachability
- * checks, and passive default-network observation.
- *
- * Source integrated from:
- * https://gist.github.com/rodrigosambadesaa/729cca29a031fef4e2f15751863b655f
+ * Further modernized for thread-safety, Android API compatibility,
+ * extensible probe strategies, and captive-portal-aware reachability checks.
  */
 @file:Suppress("DEPRECATION")
 
@@ -60,7 +56,8 @@ class ConnectivityAndInternetAccess private constructor(
     private val instanceHosts: List<String>,
     private val instanceResolvers: List<String>,
     private val instanceDnsStrategy: DnsProbeStrategy,
-    private val instanceHttpStrategy: HttpProbeStrategy
+    private val instanceHttpStrategy: HttpProbeStrategy,
+    private val instanceIcmpTargets: List<String>
 ) {
 
     /**
@@ -71,7 +68,8 @@ class ConnectivityAndInternetAccess private constructor(
         normalizeHosts(hosts),
         DEFAULT_DNS_RESOLVERS,
         DefaultDnsProbe(),
-        DefaultHttpProbe()
+        DefaultHttpProbe(),
+        DEFAULT_ICMP_TARGETS
     ) {
         globalHosts = instanceHosts
     }
@@ -88,11 +86,37 @@ class ConnectivityAndInternetAccess private constructor(
         fun onResult(result: InternetResult)
     }
 
+    /**
+     * Receives the result of the optional ICMP diagnostic.
+     *
+     * ICMP is deliberately independent from the normal DNS/HTTP reachability
+     * result. A failed ICMP probe does not mean that Internet access is unavailable.
+     */
+    fun interface IcmpCallback {
+        fun onResult(result: IcmpResult)
+    }
+
     @ConsistentCopyVisibility
     data class InternetResult internal constructor(
         val reachable: Boolean,
         val reachedHost: String?,
         val attemptedHosts: List<String>,
+        val elapsedMilliseconds: Long
+    ) {
+        fun isReachable(): Boolean = reachable
+    }
+
+    /**
+     * Result of the optional ICMP diagnostic.
+     *
+     * This is not an authoritative Internet-availability signal because many
+     * otherwise functional networks deliberately filter ICMP.
+     */
+    @ConsistentCopyVisibility
+    data class IcmpResult internal constructor(
+        val reachable: Boolean,
+        val reachedAddress: String?,
+        val attemptedAddresses: List<String>,
         val elapsedMilliseconds: Long
     ) {
         fun isReachable(): Boolean = reachable
@@ -147,7 +171,8 @@ class ConnectivityAndInternetAccess private constructor(
         context: Context,
         private val callback: NetworkStateCallback
     ) : Closeable {
-        private val applicationContext: Context = context.applicationContext ?: context
+        private val applicationContext: Context =
+            context.applicationContext ?: context
         private val connectivityManager = manager(applicationContext)
         private val closed = AtomicBoolean(false)
 
@@ -171,8 +196,6 @@ class ConnectivityAndInternetAccess private constructor(
                     private var currentDefaultNetwork: Network? = null
 
                     override fun onAvailable(network: Network) {
-                        // Android recommends waiting for onCapabilitiesChanged instead of
-                        // synchronously querying capabilities from onAvailable.
                         currentDefaultNetwork = network
                     }
 
@@ -253,6 +276,7 @@ class ConnectivityAndInternetAccess private constructor(
     class Builder {
         private var hosts: List<String> = DEFAULT_HOSTS
         private var dnsResolvers: List<String> = DEFAULT_DNS_RESOLVERS
+        private var icmpTargets: List<String> = DEFAULT_ICMP_TARGETS
         private var dnsStrategy: DnsProbeStrategy = DefaultDnsProbe()
         private var httpStrategy: HttpProbeStrategy = DefaultHttpProbe()
 
@@ -262,6 +286,14 @@ class ConnectivityAndInternetAccess private constructor(
 
         fun setDnsResolvers(resolvers: List<String>) = apply {
             this.dnsResolvers = resolvers
+        }
+
+        /**
+         * Configures targets used only by the explicit ICMP diagnostic.
+         * Defaults to 1.1.1.1 followed by 8.8.8.8.
+         */
+        fun setIcmpTargets(targets: List<String>) = apply {
+            this.icmpTargets = targets
         }
 
         fun setDnsProbeStrategy(strategy: DnsProbeStrategy) = apply {
@@ -276,11 +308,11 @@ class ConnectivityAndInternetAccess private constructor(
             normalizeHosts(hosts),
             normalizeDnsResolvers(dnsResolvers),
             dnsStrategy,
-            httpStrategy
+            httpStrategy,
+            normalizeIcmpTargets(icmpTargets)
         )
     }
 
-    // Instance API: preferred for new code.
     fun checkInternetAsync(
         context: Context,
         callback: InternetCallback
@@ -301,6 +333,20 @@ class ConnectivityAndInternetAccess private constructor(
         instanceHttpStrategy
     )
 
+    /**
+     * Runs an optional ICMP diagnostic off the caller thread.
+     *
+     * This does not participate in checkInternetAsync(). A false result must not
+     * be interpreted as "offline". The spawned ping process follows the OS routing
+     * decision and cannot be bound to an Android Network like the DNS/HTTP probes.
+     */
+    fun checkIcmpReachabilityAsync(callback: IcmpCallback): Request =
+        executeIcmpAsync(instanceIcmpTargets, callback)
+
+    /** Blocking ICMP counterpart. Do not call this from the main thread. */
+    fun checkIcmpReachabilityBlocking(): IcmpResult =
+        executeIcmpBlocking(instanceIcmpTargets)
+
     companion object {
         private const val MINIMUM_FAST_KBPS = 3_072
         private const val CONNECT_TIMEOUT_MS = 800
@@ -310,6 +356,10 @@ class ConnectivityAndInternetAccess private constructor(
         private const val DNS_STAGE_TIMEOUT_MS = 700L
         private const val TOTAL_PROBE_TIMEOUT_MS = 2_000L
         private const val MAX_PARALLEL_PROBES = 9
+        private const val ICMP_ATTEMPT_TIMEOUT_MS = 800L
+        private const val ICMP_TOTAL_TIMEOUT_MS = 1_500L
+        private const val ICMP_POLL_INTERVAL_MS = 25L
+        private const val PING_BINARY = "/system/bin/ping"
         private const val DNS_PORT = 53
         private const val CONNECTION_ATTEMPT_TIMEOUT_MS = 30_000L
         private const val DNS_QUERY_NAME = "example.com"
@@ -329,6 +379,15 @@ class ConnectivityAndInternetAccess private constructor(
             "https://www.amazon.com/"
         )
 
+        /**
+         * Numeric addresses avoid requiring forward DNS merely to start the
+         * built-in IP/ICMP diagnostic.
+         */
+        private val DEFAULT_ICMP_TARGETS = listOf(
+            "1.1.1.1",
+            "8.8.8.8"
+        )
+
         @Volatile
         private var globalHosts: List<String> = DEFAULT_HOSTS
 
@@ -344,6 +403,8 @@ class ConnectivityAndInternetAccess private constructor(
         private val connectionAttemptLock = Any()
         private val connectionAttemptQueue = ArrayDeque<ConnectionAttempt>()
         private val connectionAttempts = AtomicInteger(0)
+        private val connectionAttemptStalled = AtomicBoolean(false)
+        private var legacyConnectingSinceElapsedRealtime = -1L
         private val dnsTransactionId = AtomicInteger(System.nanoTime().toInt())
         private val probeThreadNumber = AtomicInteger(0)
 
@@ -363,7 +424,9 @@ class ConnectivityAndInternetAccess private constructor(
         @JvmStatic
         fun strictCaptivePortalBuilder(): Builder = Builder()
             .setDnsResolvers(emptyList())
-            .setHosts(listOf("https://connectivitycheck.gstatic.com/generate_204"))
+            .setHosts(
+                listOf("https://connectivitycheck.gstatic.com/generate_204")
+            )
             .setHttpProbeStrategy(StrictHttpProbe())
 
         @JvmStatic
@@ -389,32 +452,77 @@ class ConnectivityAndInternetAccess private constructor(
             }
 
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
-                if (legacyNetworks(manager(context)).any { info ->
-                        info != null &&
-                            info.isAvailable &&
-                            info.state == NetworkInfo.State.CONNECTING
-                    }
-                ) {
+                val legacyConnecting = isLegacyConnecting(manager(context))
+                updateLegacyConnectingStallState(legacyConnecting)
+                if (legacyConnecting) {
                     return true
                 }
             }
 
+            expireTimedOutConnectionAttempts()
             return connectionAttempts.get() > 0
+        }
+
+        /**
+         * Returns true when a connection attempt has remained unresolved for at
+         * least [CONNECTION_ATTEMPT_TIMEOUT_MS].
+         *
+         * API 29+ uses attempts registered with [beginConnectionAttempt]. API
+         * 16-28 also times the legacy CONNECTING state from its first observation
+         * by this helper or [isConnecting].
+         */
+        @JvmStatic
+        fun isConnectionAttemptStalled(context: Context?): Boolean {
+            context ?: throw IllegalArgumentException("context == null")
+
+            if (isConnected(context)) {
+                return false
+            }
+
+            expireTimedOutConnectionAttempts()
+            if (connectionAttemptStalled.get()) {
+                return true
+            }
+
+            return if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+                updateLegacyConnectingStallState(
+                    isLegacyConnecting(manager(context))
+                )
+            } else {
+                false
+            }
+        }
+
+        @JvmStatic
+        fun clearConnectionAttemptStall() {
+            synchronized(connectionAttemptLock) {
+                connectionAttemptStalled.set(false)
+                legacyConnectingSinceElapsedRealtime = -1L
+            }
         }
 
         @JvmStatic
         fun beginConnectionAttempt(context: Context) {
-            // Keep the context parameter for API compatibility and its non-null contract.
-            context.applicationContext
-
-            val attempt = ConnectionAttempt()
+            val safeContext = context.applicationContext ?: context
+            val attempt: ConnectionAttempt
             synchronized(connectionAttemptLock) {
+                if (connectionAttempts.get() == 0) {
+                    connectionAttemptStalled.set(false)
+                    legacyConnectingSinceElapsedRealtime = -1L
+                }
+                // Timestamp at enqueue time so queue order and timeout order cannot
+                // diverge when several callers begin attempts concurrently.
+                attempt = ConnectionAttempt(SystemClock.elapsedRealtime())
                 connectionAttemptQueue.addLast(attempt)
                 connectionAttempts.incrementAndGet()
             }
 
             mainHandler.postDelayed(
-                { closeConnectionAttempt(attempt) },
+                {
+                    if (!isConnected(safeContext)) {
+                        timeoutConnectionAttempt(attempt)
+                    }
+                },
                 CONNECTION_ATTEMPT_TIMEOUT_MS
             )
         }
@@ -454,6 +562,7 @@ class ConnectivityAndInternetAccess private constructor(
                 }
             }
 
+            expireTimedOutConnectionAttempts()
             return connectionAttempts.get() > 0
         }
 
@@ -497,7 +606,8 @@ class ConnectivityAndInternetAccess private constructor(
             val connectivityManager = manager(context)
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                val active = connectivityManager.activeNetwork ?: return disconnectedNetworkState()
+                val active = connectivityManager.activeNetwork
+                    ?: return disconnectedNetworkState()
                 return networkStateFromCapabilities(
                     connectivityManager.getNetworkCapabilities(active)
                 )
@@ -691,8 +801,9 @@ class ConnectivityAndInternetAccess private constructor(
             }
         }
 
-        // Static compatibility helpers. Names intentionally differ from the instance
-        // methods to avoid duplicate JVM signatures.
+        // Static compatibility helpers. Their names intentionally differ from
+        // the instance methods to avoid duplicate JVM signatures.
+
         @JvmStatic
         fun isInternetReachable(context: Context?): Boolean {
             context ?: throw IllegalArgumentException("context == null")
@@ -799,10 +910,148 @@ class ConnectivityAndInternetAccess private constructor(
         )
 
         @JvmStatic
+        fun checkIcmpReachabilityAsyncDefault(
+            callback: IcmpCallback
+        ): Request = executeIcmpAsync(DEFAULT_ICMP_TARGETS, callback)
+
+        @JvmStatic
+        fun checkIcmpReachabilityBlockingDefault(): IcmpResult =
+            executeIcmpBlocking(DEFAULT_ICMP_TARGETS)
+
+        @JvmStatic
         fun defaultHosts(): List<String> = DEFAULT_HOSTS
 
         @JvmStatic
         fun defaultDnsResolvers(): List<String> = DEFAULT_DNS_RESOLVERS
+
+        @JvmStatic
+        fun defaultIcmpTargets(): List<String> = DEFAULT_ICMP_TARGETS
+
+        private fun executeIcmpAsync(
+            targets: List<String>,
+            callback: IcmpCallback
+        ): Request {
+            val normalizedTargets = normalizeIcmpTargets(targets)
+            val request = Request()
+
+            request.attach(
+                executor.submit {
+                    val result = executeIcmpBlocking(normalizedTargets)
+                    if (!request.isCancelled()) {
+                        mainHandler.post {
+                            if (!request.isCancelled()) {
+                                callback.onResult(result)
+                            }
+                        }
+                    }
+                }
+            )
+
+            return request
+        }
+
+        private fun executeIcmpBlocking(targets: List<String>): IcmpResult {
+            val started = SystemClock.elapsedRealtime()
+            val deadline = started + ICMP_TOTAL_TIMEOUT_MS
+            val attempted = mutableListOf<String>()
+
+            for (target in normalizeIcmpTargets(targets)) {
+                if (Thread.currentThread().isInterrupted ||
+                    SystemClock.elapsedRealtime() >= deadline
+                ) {
+                    break
+                }
+
+                attempted += target
+                val attemptDeadline = minOf(
+                    deadline,
+                    SystemClock.elapsedRealtime() + ICMP_ATTEMPT_TIMEOUT_MS
+                )
+
+                if (checkIcmpTarget(target, attemptDeadline)) {
+                    return IcmpResult(
+                        reachable = true,
+                        reachedAddress = target,
+                        attemptedAddresses = attempted.toList(),
+                        elapsedMilliseconds =
+                            SystemClock.elapsedRealtime() - started
+                    )
+                }
+            }
+
+            return IcmpResult(
+                reachable = false,
+                reachedAddress = null,
+                attemptedAddresses = attempted.toList(),
+                elapsedMilliseconds = SystemClock.elapsedRealtime() - started
+            )
+        }
+
+        private fun checkIcmpTarget(target: String, deadline: Long): Boolean {
+            var process: Process? = null
+
+            return try {
+                process = startPingProcess(target)
+
+                // ping never needs stdin.
+                process.outputStream.closeQuietly()
+
+                while (!Thread.currentThread().isInterrupted) {
+                    try {
+                        return process.exitValue() == 0
+                    } catch (_: IllegalThreadStateException) {
+                        // Still running; enforce an API-16-safe deadline ourselves.
+                    }
+
+                    val remaining = deadline - SystemClock.elapsedRealtime()
+                    if (remaining <= 0) {
+                        return false
+                    }
+
+                    try {
+                        Thread.sleep(minOf(ICMP_POLL_INTERVAL_MS, remaining))
+                    } catch (_: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                        return false
+                    }
+                }
+
+                false
+            } catch (_: IOException) {
+                false
+            } catch (_: RuntimeException) {
+                false
+            } finally {
+                process?.let { running ->
+                    try {
+                        running.destroy()
+                    } catch (_: RuntimeException) {
+                        // Best-effort teardown on unusual OEM implementations.
+                    }
+
+                    running.inputStream.closeQuietly()
+                    running.errorStream.closeQuietly()
+                    running.outputStream.closeQuietly()
+                }
+            }
+        }
+
+        private fun startPingProcess(target: String): Process =
+            try {
+                ProcessBuilder(PING_BINARY, "-c", "1", target)
+                    .redirectErrorStream(true)
+                    .start()
+            } catch (primaryFailure: IOException) {
+                try {
+                    ProcessBuilder("ping", "-c", "1", target)
+                        .redirectErrorStream(true)
+                        .start()
+                } catch (fallbackFailure: IOException) {
+                    // Keep the fallback path compatible with Android API 16-18;
+                    // the suppressed-exception API is not available there.
+                    throw fallbackFailure
+                }
+            }
 
         private fun executeAsync(
             context: Context,
@@ -877,11 +1126,18 @@ class ConnectivityAndInternetAccess private constructor(
                 var reached: String?
 
                 /*
-                 * Prefer DNS configured for the selected Android Network before direct
-                 * public resolvers. This respects VPN and Private DNS routing. An empty
-                 * resolver list disables the entire DNS stage; a custom strategy owns it.
+                 * Prefer the DNS configuration of the selected Android Network before
+                 * contacting public resolvers directly. This respects the effective
+                 * network path (including VPN and Private DNS on modern Android).
+                 *
+                 * An empty resolver list still disables the entire DNS stage, preserving
+                 * the historical Builder semantics and strict captive-portal mode.
+                 * A custom DnsProbeStrategy also owns the DNS stage completely, so the
+                 * built-in effective-DNS preflight is only used with DefaultDnsProbe.
                  */
-                if (normalizedResolvers.isNotEmpty() && dnsStrategy is DefaultDnsProbe) {
+                if (normalizedResolvers.isNotEmpty() &&
+                    dnsStrategy is DefaultDnsProbe
+                ) {
                     reached = raceProbes(
                         listOf(
                             ProbeAttempt(effectiveDnsLabel()) {
@@ -889,7 +1145,10 @@ class ConnectivityAndInternetAccess private constructor(
                             }
                         ),
                         attempted,
-                        minOf(deadline, started + EFFECTIVE_DNS_STAGE_TIMEOUT_MS),
+                        minOf(
+                            deadline,
+                            started + EFFECTIVE_DNS_STAGE_TIMEOUT_MS
+                        ),
                         probeExecutor
                     )
 
@@ -992,7 +1251,8 @@ class ConnectivityAndInternetAccess private constructor(
                         return null
                     }
 
-                    val completed = completion.poll(wait, TimeUnit.MILLISECONDS) ?: return null
+                    val completed = completion.poll(wait, TimeUnit.MILLISECONDS)
+                        ?: return null
 
                     try {
                         completed.get()?.let { return it }
@@ -1014,7 +1274,8 @@ class ConnectivityAndInternetAccess private constructor(
         private fun checkEffectiveDns(network: Network?): Boolean =
             try {
                 val addresses = if (
-                    network != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                    network != null &&
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
                 ) {
                     network.getAllByName(DNS_QUERY_NAME)
                 } else {
@@ -1027,7 +1288,8 @@ class ConnectivityAndInternetAccess private constructor(
                 false
             }
 
-        private fun effectiveDnsLabel(): String = "dns://system/$DNS_QUERY_NAME"
+        private fun effectiveDnsLabel(): String =
+            "dns://system/$DNS_QUERY_NAME"
 
         class DefaultDnsProbe : DnsProbeStrategy {
             override fun checkDns(resolver: String, network: Network?): Boolean {
@@ -1039,8 +1301,7 @@ class ConnectivityAndInternetAccess private constructor(
                     val query = createDnsQuery(transactionId)
 
                     socket = DatagramSocket()
-                    if (
-                        network != null &&
+                    if (network != null &&
                         Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
                     ) {
                         network.bindSocket(socket)
@@ -1054,7 +1315,11 @@ class ConnectivityAndInternetAccess private constructor(
                     val response = DatagramPacket(buffer, buffer.size)
                     socket.receive(response)
 
-                    isValidDnsResponse(transactionId, response.data, response.length)
+                    isValidDnsResponse(
+                        transactionId,
+                        response.data,
+                        response.length
+                    )
                 } catch (_: IOException) {
                     false
                 } catch (_: RuntimeException) {
@@ -1128,8 +1393,7 @@ class ConnectivityAndInternetAccess private constructor(
                 return try {
                     val url = URL(address)
                     val raw: URLConnection =
-                        if (
-                            network != null &&
+                        if (network != null &&
                             Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
                         ) {
                             network.openConnection(url)
@@ -1171,8 +1435,7 @@ class ConnectivityAndInternetAccess private constructor(
                 return try {
                     val url = URL(address)
                     val raw: URLConnection =
-                        if (
-                            network != null &&
+                        if (network != null &&
                             Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
                         ) {
                             network.openConnection(url)
@@ -1214,8 +1477,7 @@ class ConnectivityAndInternetAccess private constructor(
         }
 
         private fun configureTlsIfNecessary(connection: HttpURLConnection) {
-            if (
-                connection is HttpsURLConnection &&
+            if (connection is HttpsURLConnection &&
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN &&
                 Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP
             ) {
@@ -1258,8 +1520,7 @@ class ConnectivityAndInternetAccess private constructor(
                 ?: throw IllegalStateException("ConnectivityManager unavailable")
 
         private fun NetworkCapabilities?.isUsable(): Boolean {
-            if (
-                this == null ||
+            if (this == null ||
                 !hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
             ) {
                 return false
@@ -1275,7 +1536,8 @@ class ConnectivityAndInternetAccess private constructor(
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 return connectivityManager.allNetworks.any { network ->
-                    val capabilities = connectivityManager.getNetworkCapabilities(network)
+                    val capabilities =
+                        connectivityManager.getNetworkCapabilities(network)
                     capabilities.isUsable() &&
                         capabilities?.hasTransport(transport) == true
                 }
@@ -1332,9 +1594,36 @@ class ConnectivityAndInternetAccess private constructor(
         private fun NetworkInfo?.isConnectedLegacy(): Boolean =
             this != null && isAvailable && isConnected
 
+        private fun isLegacyConnecting(
+            connectivityManager: ConnectivityManager
+        ): Boolean = legacyNetworks(connectivityManager).any { info ->
+            info != null &&
+                info.isAvailable &&
+                info.state == NetworkInfo.State.CONNECTING
+        }
+
+        private fun updateLegacyConnectingStallState(
+            connecting: Boolean
+        ): Boolean {
+            synchronized(connectionAttemptLock) {
+                if (!connecting) {
+                    legacyConnectingSinceElapsedRealtime = -1L
+                    return false
+                }
+
+                val now = SystemClock.elapsedRealtime()
+                if (legacyConnectingSinceElapsedRealtime < 0L) {
+                    legacyConnectingSinceElapsedRealtime = now
+                    return false
+                }
+
+                return now - legacyConnectingSinceElapsedRealtime >=
+                    CONNECTION_ATTEMPT_TIMEOUT_MS
+            }
+        }
+
         private fun isConnectionFast(type: Int, subType: Int): Boolean {
-            if (
-                type == ConnectivityManager.TYPE_WIFI ||
+            if (type == ConnectivityManager.TYPE_WIFI ||
                 type == ConnectivityManager.TYPE_ETHERNET
             ) {
                 return true
@@ -1369,8 +1658,7 @@ class ConnectivityAndInternetAccess private constructor(
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 val active = connectivityManager.activeNetwork
-                if (
-                    active != null &&
+                if (active != null &&
                     connectivityManager.getNetworkCapabilities(active).isUsable()
                 ) {
                     return active
@@ -1383,6 +1671,33 @@ class ConnectivityAndInternetAccess private constructor(
             }
         }
 
+        private fun normalizeIcmpTargets(targets: List<String>): List<String> {
+            val normalized = LinkedHashSet<String>()
+
+            for (raw in targets) {
+                val value = raw.trim()
+                if (value.isEmpty()) {
+                    continue
+                }
+
+                /*
+                 * ProcessBuilder already avoids shell injection. Validation also
+                 * rejects option-looking values and command/path punctuation while
+                 * retaining IPv4, IPv6 zone identifiers and ordinary host names.
+                 */
+                require(
+                    !value.startsWith("-") &&
+                        value.matches(Regex("[A-Za-z0-9._:%-]+"))
+                ) {
+                    "Invalid ICMP target: $value"
+                }
+
+                normalized += value
+            }
+
+            return normalized.toList()
+        }
+
         private fun normalizeHosts(hosts: List<String>): List<String> {
             val normalized = LinkedHashSet<String>()
 
@@ -1393,8 +1708,7 @@ class ConnectivityAndInternetAccess private constructor(
                 }
 
                 val value =
-                    if (
-                        trimmed.startsWith("https://", ignoreCase = true) ||
+                    if (trimmed.startsWith("https://", ignoreCase = true) ||
                         trimmed.startsWith("http://", ignoreCase = true)
                     ) {
                         trimmed
@@ -1459,7 +1773,7 @@ class ConnectivityAndInternetAccess private constructor(
                 "Invalid DNS resolver"
             }
 
-            val host: String
+            var host: String
             var port = DNS_PORT
 
             if (value.startsWith("[")) {
@@ -1504,6 +1818,18 @@ class ConnectivityAndInternetAccess private constructor(
             return port
         }
 
+        private fun Closeable?.closeQuietly() {
+            if (this == null) {
+                return
+            }
+
+            try {
+                close()
+            } catch (_: IOException) {
+                // Best-effort process-stream cleanup.
+            }
+        }
+
         private fun newProbeExecutor(): ExecutorService =
             Executors.newFixedThreadPool(
                 MAX_PARALLEL_PROBES,
@@ -1517,7 +1843,7 @@ class ConnectivityAndInternetAccess private constructor(
                 }
             )
 
-        private fun closeConnectionAttempt(attempt: ConnectionAttempt): Boolean {
+        private fun timeoutConnectionAttempt(attempt: ConnectionAttempt): Boolean {
             synchronized(connectionAttemptLock) {
                 if (attempt.closed) {
                     return false
@@ -1528,7 +1854,35 @@ class ConnectivityAndInternetAccess private constructor(
                 connectionAttempts.updateAndGet { value ->
                     if (value > 0) value - 1 else 0
                 }
+                connectionAttemptStalled.set(true)
                 return true
+            }
+        }
+
+        private fun expireTimedOutConnectionAttempts() {
+            val now = SystemClock.elapsedRealtime()
+
+            synchronized(connectionAttemptLock) {
+                while (connectionAttemptQueue.isNotEmpty()) {
+                    val attempt = connectionAttemptQueue.first()
+                    if (attempt.closed) {
+                        connectionAttemptQueue.removeFirst()
+                        continue
+                    }
+                    if (
+                        now - attempt.startedAtElapsedRealtime <
+                        CONNECTION_ATTEMPT_TIMEOUT_MS
+                    ) {
+                        break
+                    }
+
+                    attempt.closed = true
+                    connectionAttemptQueue.removeFirst()
+                    connectionAttempts.updateAndGet { value ->
+                        if (value > 0) value - 1 else 0
+                    }
+                    connectionAttemptStalled.set(true)
+                }
             }
         }
 
@@ -1539,6 +1893,8 @@ class ConnectivityAndInternetAccess private constructor(
                 }
                 connectionAttemptQueue.clear()
                 connectionAttempts.set(0)
+                connectionAttemptStalled.set(false)
+                legacyConnectingSinceElapsedRealtime = -1L
             }
         }
 
@@ -1552,13 +1908,14 @@ class ConnectivityAndInternetAccess private constructor(
             val port: Int
         )
 
-        private class ConnectionAttempt {
+        private class ConnectionAttempt(
+            val startedAtElapsedRealtime: Long
+        ) {
             var closed: Boolean = false
         }
 
         private fun createTls12Factory(): SSLSocketFactory? {
-            if (
-                Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN ||
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN ||
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
             ) {
                 return null
@@ -1613,8 +1970,7 @@ class ConnectivityAndInternetAccess private constructor(
             )
 
             private fun enable(socket: Socket): Socket {
-                if (
-                    socket is SSLSocket &&
+                if (socket is SSLSocket &&
                     socket.supportedProtocols.contains("TLSv1.2")
                 ) {
                     socket.enabledProtocols = arrayOf("TLSv1.2")
@@ -1624,3 +1980,4 @@ class ConnectivityAndInternetAccess private constructor(
         }
     }
 }
+

--- a/shared/network/src/androidMain/kotlin/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt
+++ b/shared/network/src/androidMain/kotlin/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt
@@ -55,8 +55,14 @@ import javax.net.ssl.SSLSocketFactory
 class ConnectivityAndInternetAccess private constructor(
     private val instanceHosts: List<String>,
     private val instanceResolvers: List<String>,
+    private val instanceTcpTargets: List<String>,
+    private val instanceNtpTargets: List<String>,
+    private val instanceTlsTargets: List<String>,
     private val instanceDnsStrategy: DnsProbeStrategy,
     private val instanceHttpStrategy: HttpProbeStrategy,
+    private val instanceTcpStrategy: TcpProbeStrategy,
+    private val instanceNtpStrategy: NtpProbeStrategy,
+    private val instanceTlsStrategy: TlsProbeStrategy,
     private val instanceIcmpTargets: List<String>
 ) {
 
@@ -67,8 +73,14 @@ class ConnectivityAndInternetAccess private constructor(
     constructor(hosts: ArrayList<String>) : this(
         normalizeHosts(hosts),
         DEFAULT_DNS_RESOLVERS,
+        DEFAULT_TCP_TARGETS,
+        DEFAULT_NTP_TARGETS,
+        DEFAULT_TLS_TARGETS,
         DefaultDnsProbe(),
         DefaultHttpProbe(),
+        DefaultTcpProbe(),
+        DefaultNtpProbe(),
+        DefaultTlsProbe(),
         DEFAULT_ICMP_TARGETS
     ) {
         globalHosts = instanceHosts
@@ -80,6 +92,18 @@ class ConnectivityAndInternetAccess private constructor(
 
     fun interface HttpProbeStrategy {
         fun checkHttp(address: String, network: Network?): Boolean
+    }
+
+    fun interface TcpProbeStrategy {
+        fun checkTcp(host: String, port: Int, network: Network?): Boolean
+    }
+
+    fun interface NtpProbeStrategy {
+        fun checkNtp(host: String, network: Network?): Boolean
+    }
+
+    fun interface TlsProbeStrategy {
+        fun checkTls(host: String, port: Int, network: Network?): Boolean
     }
 
     fun interface InternetCallback {
@@ -196,6 +220,8 @@ class ConnectivityAndInternetAccess private constructor(
                     private var currentDefaultNetwork: Network? = null
 
                     override fun onAvailable(network: Network) {
+                        // Android explicitly recommends waiting for onCapabilitiesChanged
+                        // instead of synchronously querying capabilities from here.
                         currentDefaultNetwork = network
                     }
 
@@ -276,9 +302,15 @@ class ConnectivityAndInternetAccess private constructor(
     class Builder {
         private var hosts: List<String> = DEFAULT_HOSTS
         private var dnsResolvers: List<String> = DEFAULT_DNS_RESOLVERS
+        private var tcpTargets: List<String> = DEFAULT_TCP_TARGETS
+        private var ntpTargets: List<String> = DEFAULT_NTP_TARGETS
+        private var tlsTargets: List<String> = DEFAULT_TLS_TARGETS
         private var icmpTargets: List<String> = DEFAULT_ICMP_TARGETS
         private var dnsStrategy: DnsProbeStrategy = DefaultDnsProbe()
         private var httpStrategy: HttpProbeStrategy = DefaultHttpProbe()
+        private var tcpStrategy: TcpProbeStrategy = DefaultTcpProbe()
+        private var ntpStrategy: NtpProbeStrategy = DefaultNtpProbe()
+        private var tlsStrategy: TlsProbeStrategy = DefaultTlsProbe()
 
         fun setHosts(hosts: List<String>) = apply {
             this.hosts = hosts
@@ -288,9 +320,21 @@ class ConnectivityAndInternetAccess private constructor(
             this.dnsResolvers = resolvers
         }
 
+        fun setTcpTargets(targets: List<String>) = apply {
+            this.tcpTargets = targets
+        }
+
+        fun setNtpTargets(targets: List<String>) = apply {
+            this.ntpTargets = targets
+        }
+
+        fun setTlsTargets(targets: List<String>) = apply {
+            this.tlsTargets = targets
+        }
+
         /**
          * Configures targets used only by the explicit ICMP diagnostic.
-         * Defaults to 1.1.1.1 followed by 8.8.8.8.
+         * Defaults to 1.1.1.1, 8.8.8.8, and the Cloudflare IPv6 resolver address.
          */
         fun setIcmpTargets(targets: List<String>) = apply {
             this.icmpTargets = targets
@@ -304,14 +348,34 @@ class ConnectivityAndInternetAccess private constructor(
             this.httpStrategy = strategy
         }
 
+        fun setTcpProbeStrategy(strategy: TcpProbeStrategy) = apply {
+            this.tcpStrategy = strategy
+        }
+
+        fun setNtpProbeStrategy(strategy: NtpProbeStrategy) = apply {
+            this.ntpStrategy = strategy
+        }
+
+        fun setTlsProbeStrategy(strategy: TlsProbeStrategy) = apply {
+            this.tlsStrategy = strategy
+        }
+
         fun build(): ConnectivityAndInternetAccess = ConnectivityAndInternetAccess(
             normalizeHosts(hosts),
             normalizeDnsResolvers(dnsResolvers),
+            normalizeEndpointTargets(tcpTargets, HTTPS_PORT, "tcpTargets"),
+            normalizeNtpTargets(ntpTargets),
+            normalizeEndpointTargets(tlsTargets, HTTPS_PORT, "tlsTargets"),
             dnsStrategy,
             httpStrategy,
+            tcpStrategy,
+            ntpStrategy,
+            tlsStrategy,
             normalizeIcmpTargets(icmpTargets)
         )
     }
+
+    // Instance API: preferred for new code.
 
     fun checkInternetAsync(
         context: Context,
@@ -320,8 +384,14 @@ class ConnectivityAndInternetAccess private constructor(
         context,
         instanceResolvers,
         instanceHosts,
+        instanceTcpTargets,
+        instanceNtpTargets,
+        instanceTlsTargets,
         instanceDnsStrategy,
         instanceHttpStrategy,
+        instanceTcpStrategy,
+        instanceNtpStrategy,
+        instanceTlsStrategy,
         callback
     )
 
@@ -329,8 +399,14 @@ class ConnectivityAndInternetAccess private constructor(
         context,
         instanceResolvers,
         instanceHosts,
+        instanceTcpTargets,
+        instanceNtpTargets,
+        instanceTlsTargets,
         instanceDnsStrategy,
-        instanceHttpStrategy
+        instanceHttpStrategy,
+        instanceTcpStrategy,
+        instanceNtpStrategy,
+        instanceTlsStrategy
     )
 
     /**
@@ -349,18 +425,20 @@ class ConnectivityAndInternetAccess private constructor(
 
     companion object {
         private const val MINIMUM_FAST_KBPS = 3_072
-        private const val CONNECT_TIMEOUT_MS = 800
-        private const val READ_TIMEOUT_MS = 800
-        private const val DNS_TIMEOUT_MS = 650
-        private const val EFFECTIVE_DNS_STAGE_TIMEOUT_MS = 350L
-        private const val DNS_STAGE_TIMEOUT_MS = 700L
-        private const val TOTAL_PROBE_TIMEOUT_MS = 2_000L
-        private const val MAX_PARALLEL_PROBES = 9
+        private const val CONNECT_TIMEOUT_MS = 3_000
+        private const val READ_TIMEOUT_MS = 3_000
+        private const val DNS_TIMEOUT_MS = 2_500
+        private const val EFFECTIVE_DNS_STAGE_TIMEOUT_MS = 1_500L
+        private const val DNS_STAGE_TIMEOUT_MS = 3_500L
+        private const val TOTAL_PROBE_TIMEOUT_MS = 6_000L
+        private const val MAX_PARALLEL_PROBES = 16
         private const val ICMP_ATTEMPT_TIMEOUT_MS = 800L
         private const val ICMP_TOTAL_TIMEOUT_MS = 1_500L
         private const val ICMP_POLL_INTERVAL_MS = 25L
         private const val PING_BINARY = "/system/bin/ping"
         private const val DNS_PORT = 53
+        private const val NTP_PORT = 123
+        private const val HTTPS_PORT = 443
         private const val CONNECTION_ATTEMPT_TIMEOUT_MS = 30_000L
         private const val DNS_QUERY_NAME = "example.com"
 
@@ -368,7 +446,8 @@ class ConnectivityAndInternetAccess private constructor(
             "1.1.1.1",
             "8.8.8.8",
             "9.9.9.9",
-            "208.67.222.222"
+            "208.67.222.222",
+            "[2606:4700:4700::1111]"
         )
 
         private val DEFAULT_HOSTS = listOf(
@@ -383,9 +462,26 @@ class ConnectivityAndInternetAccess private constructor(
          * Numeric addresses avoid requiring forward DNS merely to start the
          * built-in IP/ICMP diagnostic.
          */
+        private val DEFAULT_TCP_TARGETS = listOf(
+            "1.1.1.1:53",
+            "8.8.8.8:443",
+            "[2606:4700:4700::1111]:53"
+        )
+
+        private val DEFAULT_NTP_TARGETS = listOf(
+            "time.google.com",
+            "pool.ntp.org"
+        )
+
+        private val DEFAULT_TLS_TARGETS = listOf(
+            "www.google.com:443",
+            "cloudflare.com:443"
+        )
+
         private val DEFAULT_ICMP_TARGETS = listOf(
             "1.1.1.1",
-            "8.8.8.8"
+            "8.8.8.8",
+            "[2606:4700:4700::1111]"
         )
 
         @Volatile
@@ -395,11 +491,28 @@ class ConnectivityAndInternetAccess private constructor(
         private var globalResolvers: List<String> = DEFAULT_DNS_RESOLVERS
 
         @Volatile
+        private var globalTcpTargets: List<String> = DEFAULT_TCP_TARGETS
+
+        @Volatile
+        private var globalNtpTargets: List<String> = DEFAULT_NTP_TARGETS
+
+        @Volatile
+        private var globalTlsTargets: List<String> = DEFAULT_TLS_TARGETS
+
+        @Volatile
         private var globalDnsStrategy: DnsProbeStrategy = DefaultDnsProbe()
 
         @Volatile
         private var globalHttpStrategy: HttpProbeStrategy = DefaultHttpProbe()
 
+        @Volatile
+        private var globalTcpStrategy: TcpProbeStrategy = DefaultTcpProbe()
+
+        @Volatile
+        private var globalNtpStrategy: NtpProbeStrategy = DefaultNtpProbe()
+
+        @Volatile
+        private var globalTlsStrategy: TlsProbeStrategy = DefaultTlsProbe()
         private val connectionAttemptLock = Any()
         private val connectionAttemptQueue = ArrayDeque<ConnectionAttempt>()
         private val connectionAttempts = AtomicInteger(0)
@@ -424,6 +537,9 @@ class ConnectivityAndInternetAccess private constructor(
         @JvmStatic
         fun strictCaptivePortalBuilder(): Builder = Builder()
             .setDnsResolvers(emptyList())
+            .setTcpTargets(emptyList())
+            .setNtpTargets(emptyList())
+            .setTlsTargets(emptyList())
             .setHosts(
                 listOf("https://connectivitycheck.gstatic.com/generate_204")
             )
@@ -446,11 +562,9 @@ class ConnectivityAndInternetAccess private constructor(
         @JvmStatic
         fun isConnecting(context: Context?): Boolean {
             context ?: throw IllegalArgumentException("context == null")
-
             if (isConnected(context)) {
                 return false
             }
-
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
                 val legacyConnecting = isLegacyConnecting(manager(context))
                 updateLegacyConnectingStallState(legacyConnecting)
@@ -458,11 +572,9 @@ class ConnectivityAndInternetAccess private constructor(
                     return true
                 }
             }
-
             expireTimedOutConnectionAttempts()
             return connectionAttempts.get() > 0
         }
-
         /**
          * Returns true when a connection attempt has remained unresolved for at
          * least [CONNECTION_ATTEMPT_TIMEOUT_MS].
@@ -504,19 +616,14 @@ class ConnectivityAndInternetAccess private constructor(
         @JvmStatic
         fun beginConnectionAttempt(context: Context) {
             val safeContext = context.applicationContext ?: context
-            val attempt: ConnectionAttempt
+            val attempt = ConnectionAttempt(SystemClock.elapsedRealtime())
             synchronized(connectionAttemptLock) {
                 if (connectionAttempts.get() == 0) {
                     connectionAttemptStalled.set(false)
-                    legacyConnectingSinceElapsedRealtime = -1L
                 }
-                // Timestamp at enqueue time so queue order and timeout order cannot
-                // diverge when several callers begin attempts concurrently.
-                attempt = ConnectionAttempt(SystemClock.elapsedRealtime())
                 connectionAttemptQueue.addLast(attempt)
                 connectionAttempts.incrementAndGet()
             }
-
             mainHandler.postDelayed(
                 {
                     if (!isConnected(safeContext)) {
@@ -562,7 +669,6 @@ class ConnectivityAndInternetAccess private constructor(
                 }
             }
 
-            expireTimedOutConnectionAttempts()
             return connectionAttempts.get() > 0
         }
 
@@ -811,8 +917,14 @@ class ConnectivityAndInternetAccess private constructor(
                 context,
                 globalResolvers,
                 globalHosts,
+                globalTcpTargets,
+                globalNtpTargets,
+                globalTlsTargets,
                 globalDnsStrategy,
-                globalHttpStrategy
+                globalHttpStrategy,
+                globalTcpStrategy,
+                globalNtpStrategy,
+                globalTlsStrategy
             ).reachable
         }
 
@@ -826,8 +938,14 @@ class ConnectivityAndInternetAccess private constructor(
                 context,
                 globalResolvers,
                 normalizeHosts(hosts),
+                globalTcpTargets,
+                globalNtpTargets,
+                globalTlsTargets,
                 globalDnsStrategy,
-                globalHttpStrategy
+                globalHttpStrategy,
+                globalTcpStrategy,
+                globalNtpStrategy,
+                globalTlsStrategy
             ).reachable
         }
 
@@ -839,8 +957,14 @@ class ConnectivityAndInternetAccess private constructor(
             context,
             globalResolvers,
             globalHosts,
+            globalTcpTargets,
+            globalNtpTargets,
+            globalTlsTargets,
             globalDnsStrategy,
             globalHttpStrategy,
+            globalTcpStrategy,
+            globalNtpStrategy,
+            globalTlsStrategy,
             callback
         )
 
@@ -853,8 +977,14 @@ class ConnectivityAndInternetAccess private constructor(
             context,
             globalResolvers,
             hosts,
+            globalTcpTargets,
+            globalNtpTargets,
+            globalTlsTargets,
             globalDnsStrategy,
             globalHttpStrategy,
+            globalTcpStrategy,
+            globalNtpStrategy,
+            globalTlsStrategy,
             callback
         )
 
@@ -868,8 +998,14 @@ class ConnectivityAndInternetAccess private constructor(
             context,
             dnsResolvers,
             hosts,
+            globalTcpTargets,
+            globalNtpTargets,
+            globalTlsTargets,
             globalDnsStrategy,
             globalHttpStrategy,
+            globalTcpStrategy,
+            globalNtpStrategy,
+            globalTlsStrategy,
             callback
         )
 
@@ -880,8 +1016,14 @@ class ConnectivityAndInternetAccess private constructor(
             context,
             globalResolvers,
             globalHosts,
+            globalTcpTargets,
+            globalNtpTargets,
+            globalTlsTargets,
             globalDnsStrategy,
-            globalHttpStrategy
+            globalHttpStrategy,
+            globalTcpStrategy,
+            globalNtpStrategy,
+            globalTlsStrategy
         )
 
         @JvmStatic
@@ -892,8 +1034,14 @@ class ConnectivityAndInternetAccess private constructor(
             context,
             globalResolvers,
             hosts,
+            globalTcpTargets,
+            globalNtpTargets,
+            globalTlsTargets,
             globalDnsStrategy,
-            globalHttpStrategy
+            globalHttpStrategy,
+            globalTcpStrategy,
+            globalNtpStrategy,
+            globalTlsStrategy
         )
 
         @JvmStatic
@@ -905,8 +1053,14 @@ class ConnectivityAndInternetAccess private constructor(
             context,
             dnsResolvers,
             hosts,
+            globalTcpTargets,
+            globalNtpTargets,
+            globalTlsTargets,
             globalDnsStrategy,
-            globalHttpStrategy
+            globalHttpStrategy,
+            globalTcpStrategy,
+            globalNtpStrategy,
+            globalTlsStrategy
         )
 
         @JvmStatic
@@ -923,6 +1077,15 @@ class ConnectivityAndInternetAccess private constructor(
 
         @JvmStatic
         fun defaultDnsResolvers(): List<String> = DEFAULT_DNS_RESOLVERS
+
+        @JvmStatic
+        fun defaultTcpTargets(): List<String> = DEFAULT_TCP_TARGETS
+
+        @JvmStatic
+        fun defaultNtpTargets(): List<String> = DEFAULT_NTP_TARGETS
+
+        @JvmStatic
+        fun defaultTlsTargets(): List<String> = DEFAULT_TLS_TARGETS
 
         @JvmStatic
         fun defaultIcmpTargets(): List<String> = DEFAULT_ICMP_TARGETS
@@ -1038,17 +1201,15 @@ class ConnectivityAndInternetAccess private constructor(
 
         private fun startPingProcess(target: String): Process =
             try {
-                ProcessBuilder(PING_BINARY, "-c", "1", target)
+                ProcessBuilder(PING_BINARY, "-c", "1", stripAddressBrackets(target))
                     .redirectErrorStream(true)
                     .start()
             } catch (primaryFailure: IOException) {
                 try {
-                    ProcessBuilder("ping", "-c", "1", target)
+                    ProcessBuilder("ping", "-c", "1", stripAddressBrackets(target))
                         .redirectErrorStream(true)
                         .start()
                 } catch (fallbackFailure: IOException) {
-                    // Keep the fallback path compatible with Android API 16-18;
-                    // the suppressed-exception API is not available there.
                     throw fallbackFailure
                 }
             }
@@ -1057,13 +1218,22 @@ class ConnectivityAndInternetAccess private constructor(
             context: Context,
             dnsResolvers: List<String>,
             hosts: List<String>,
+            tcpTargets: List<String>,
+            ntpTargets: List<String>,
+            tlsTargets: List<String>,
             dnsStrategy: DnsProbeStrategy,
             httpStrategy: HttpProbeStrategy,
+            tcpStrategy: TcpProbeStrategy,
+            ntpStrategy: NtpProbeStrategy,
+            tlsStrategy: TlsProbeStrategy,
             callback: InternetCallback
         ): Request {
             val appContext = context.applicationContext ?: context
             val normalizedResolvers = normalizeDnsResolvers(dnsResolvers)
             val normalizedHosts = normalizeHosts(hosts)
+            val normalizedTcpTargets = normalizeEndpointTargets(tcpTargets, HTTPS_PORT, "tcpTargets")
+            val normalizedNtpTargets = normalizeNtpTargets(ntpTargets)
+            val normalizedTlsTargets = normalizeEndpointTargets(tlsTargets, HTTPS_PORT, "tlsTargets")
             val request = Request()
 
             request.attach(
@@ -1072,8 +1242,14 @@ class ConnectivityAndInternetAccess private constructor(
                         appContext,
                         normalizedResolvers,
                         normalizedHosts,
+                        normalizedTcpTargets,
+                        normalizedNtpTargets,
+                        normalizedTlsTargets,
                         dnsStrategy,
-                        httpStrategy
+                        httpStrategy,
+                        tcpStrategy,
+                        ntpStrategy,
+                        tlsStrategy
                     )
 
                     if (!request.isCancelled()) {
@@ -1093,8 +1269,14 @@ class ConnectivityAndInternetAccess private constructor(
             context: Context,
             dnsResolvers: List<String>,
             hosts: List<String>,
+            tcpTargets: List<String>,
+            ntpTargets: List<String>,
+            tlsTargets: List<String>,
             dnsStrategy: DnsProbeStrategy,
-            httpStrategy: HttpProbeStrategy
+            httpStrategy: HttpProbeStrategy,
+            tcpStrategy: TcpProbeStrategy,
+            ntpStrategy: NtpProbeStrategy,
+            tlsStrategy: TlsProbeStrategy
         ): InternetResult {
             val started = SystemClock.elapsedRealtime()
             val deadline = started + TOTAL_PROBE_TIMEOUT_MS
@@ -1104,20 +1286,10 @@ class ConnectivityAndInternetAccess private constructor(
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 if (network == null) {
-                    return InternetResult(
-                        false,
-                        null,
-                        attempted.toList(),
-                        SystemClock.elapsedRealtime() - started
-                    )
+                    return InternetResult(false, null, attempted.toList(), SystemClock.elapsedRealtime() - started)
                 }
             } else if (!isConnected(context)) {
-                return InternetResult(
-                    false,
-                    null,
-                    attempted.toList(),
-                    SystemClock.elapsedRealtime() - started
-                )
+                return InternetResult(false, null, attempted.toList(), SystemClock.elapsedRealtime() - started)
             }
 
             val probeExecutor = newProbeExecutor()
@@ -1125,93 +1297,51 @@ class ConnectivityAndInternetAccess private constructor(
                 val normalizedResolvers = normalizeDnsResolvers(dnsResolvers)
                 var reached: String?
 
-                /*
-                 * Prefer the DNS configuration of the selected Android Network before
-                 * contacting public resolvers directly. This respects the effective
-                 * network path (including VPN and Private DNS on modern Android).
-                 *
-                 * An empty resolver list still disables the entire DNS stage, preserving
-                 * the historical Builder semantics and strict captive-portal mode.
-                 * A custom DnsProbeStrategy also owns the DNS stage completely, so the
-                 * built-in effective-DNS preflight is only used with DefaultDnsProbe.
-                 */
-                if (normalizedResolvers.isNotEmpty() &&
-                    dnsStrategy is DefaultDnsProbe
-                ) {
+                if (normalizedResolvers.isNotEmpty() && dnsStrategy is DefaultDnsProbe) {
                     reached = raceProbes(
-                        listOf(
-                            ProbeAttempt(effectiveDnsLabel()) {
-                                checkEffectiveDns(network)
-                            }
-                        ),
+                        listOf(ProbeAttempt(effectiveDnsLabel()) { checkEffectiveDns(network) }),
                         attempted,
-                        minOf(
-                            deadline,
-                            started + EFFECTIVE_DNS_STAGE_TIMEOUT_MS
-                        ),
+                        minOf(deadline, started + EFFECTIVE_DNS_STAGE_TIMEOUT_MS),
                         probeExecutor
                     )
-
-                    if (reached != null) {
-                        return InternetResult(
-                            true,
-                            reached,
-                            attempted.toList(),
-                            SystemClock.elapsedRealtime() - started
-                        )
-                    }
+                    if (reached != null) return InternetResult(true, reached, attempted.toList(), SystemClock.elapsedRealtime() - started)
                 }
 
-                val dnsAttempts = normalizedResolvers.map { resolver ->
-                    ProbeAttempt(dnsEndpointLabel(resolver)) {
+                val transportAttempts = mutableListOf<ProbeAttempt>()
+                normalizeDnsResolvers(dnsResolvers).forEach { resolver ->
+                    transportAttempts += ProbeAttempt(dnsEndpointLabel(resolver)) {
                         dnsStrategy.checkDns(resolver, network)
                     }
                 }
-
-                reached = raceProbes(
-                    dnsAttempts,
-                    attempted,
-                    minOf(deadline, started + DNS_STAGE_TIMEOUT_MS),
-                    probeExecutor
-                )
-
-                if (reached != null) {
-                    return InternetResult(
-                        true,
-                        reached,
-                        attempted.toList(),
-                        SystemClock.elapsedRealtime() - started
-                    )
+                normalizeEndpointTargets(tcpTargets, HTTPS_PORT, "tcpTargets").forEach { target ->
+                    val endpoint = parseEndpoint(target, HTTPS_PORT)
+                    transportAttempts += ProbeAttempt(endpointLabel("tcp", endpoint)) {
+                        tcpStrategy.checkTcp(endpoint.host, endpoint.port, network)
+                    }
                 }
-
-                val hostAttempts = normalizeHosts(hosts).map { host ->
-                    ProbeAttempt(host) {
-                        httpStrategy.checkHttp(host, network)
+                normalizeNtpTargets(ntpTargets).forEach { host ->
+                    transportAttempts += ProbeAttempt("ntp://${formatHost(host)}:$NTP_PORT") {
+                        ntpStrategy.checkNtp(host, network)
                     }
                 }
 
-                reached = raceProbes(
-                    hostAttempts,
-                    attempted,
-                    deadline,
-                    probeExecutor
-                )
+                reached = raceProbes(transportAttempts, attempted, minOf(deadline, started + DNS_STAGE_TIMEOUT_MS), probeExecutor)
+                if (reached != null) return InternetResult(true, reached, attempted.toList(), SystemClock.elapsedRealtime() - started)
 
-                if (reached != null) {
-                    return InternetResult(
-                        true,
-                        reached,
-                        attempted.toList(),
-                        SystemClock.elapsedRealtime() - started
-                    )
+                val applicationAttempts = mutableListOf<ProbeAttempt>()
+                normalizeHosts(hosts).forEach { host ->
+                    applicationAttempts += ProbeAttempt(host) { httpStrategy.checkHttp(host, network) }
+                }
+                normalizeEndpointTargets(tlsTargets, HTTPS_PORT, "tlsTargets").forEach { target ->
+                    val endpoint = parseEndpoint(target, HTTPS_PORT)
+                    applicationAttempts += ProbeAttempt(endpointLabel("tls", endpoint)) {
+                        tlsStrategy.checkTls(endpoint.host, endpoint.port, network)
+                    }
                 }
 
-                return InternetResult(
-                    false,
-                    null,
-                    attempted.toList(),
-                    SystemClock.elapsedRealtime() - started
-                )
+                reached = raceProbes(applicationAttempts, attempted, deadline, probeExecutor)
+                if (reached != null) return InternetResult(true, reached, attempted.toList(), SystemClock.elapsedRealtime() - started)
+                return InternetResult(false, null, attempted.toList(), SystemClock.elapsedRealtime() - started)
             } finally {
                 probeExecutor.shutdownNow()
             }
@@ -1291,9 +1421,100 @@ class ConnectivityAndInternetAccess private constructor(
         private fun effectiveDnsLabel(): String =
             "dns://system/$DNS_QUERY_NAME"
 
+        private fun resolveAddress(host: String, network: Network?): InetAddress {
+            val addresses = if (network != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                network.getAllByName(host)
+            } else {
+                InetAddress.getAllByName(host)
+            }
+            if (addresses.isEmpty()) {
+                throw IOException("No address for $host")
+            }
+            return addresses[0]
+        }
+
+        class DefaultTcpProbe : TcpProbeStrategy {
+            override fun checkTcp(host: String, port: Int, network: Network?): Boolean {
+                var socket: Socket? = null
+                return try {
+                    socket = Socket()
+                    if (network != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        network.bindSocket(socket)
+                    }
+                    socket.connect(InetSocketAddress(resolveAddress(host, network), port), CONNECT_TIMEOUT_MS)
+                    true
+                } catch (_: IOException) {
+                    false
+                } catch (_: RuntimeException) {
+                    false
+                } finally {
+                    try { socket?.close() } catch (_: IOException) { }
+                }
+            }
+        }
+
+        class DefaultNtpProbe : NtpProbeStrategy {
+            override fun checkNtp(host: String, network: Network?): Boolean {
+                var socket: DatagramSocket? = null
+                return try {
+                    socket = DatagramSocket()
+                    if (network != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+                        network.bindSocket(socket)
+                    }
+                    socket.soTimeout = DNS_TIMEOUT_MS
+                    val address = resolveAddress(host, network)
+                    val request = ByteArray(48)
+                    request[0] = 0x1B
+                    socket.send(DatagramPacket(request, request.size, address, NTP_PORT))
+                    val response = DatagramPacket(ByteArray(48), 48)
+                    socket.receive(response)
+                    response.length >= 48
+                } catch (_: IOException) {
+                    false
+                } catch (_: RuntimeException) {
+                    false
+                } finally {
+                    socket?.close()
+                }
+            }
+        }
+
+        class DefaultTlsProbe : TlsProbeStrategy {
+            override fun checkTls(host: String, port: Int, network: Network?): Boolean {
+                var socket: Socket? = null
+                var sslSocket: SSLSocket? = null
+                return try {
+                    socket = Socket()
+                    if (network != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        network.bindSocket(socket)
+                    }
+                    socket.connect(InetSocketAddress(resolveAddress(host, network), port), CONNECT_TIMEOUT_MS)
+                    socket.soTimeout = READ_TIMEOUT_MS
+                    val factory = tls12SocketFactory ?: (SSLSocketFactory.getDefault() as SSLSocketFactory)
+                    sslSocket = factory.createSocket(socket, host, port, true) as SSLSocket
+                    sslSocket.soTimeout = READ_TIMEOUT_MS
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP &&
+                        sslSocket.supportedProtocols.contains("TLSv1.2")) {
+                        sslSocket.enabledProtocols = arrayOf("TLSv1.2")
+                    }
+                    sslSocket.startHandshake()
+                    true
+                } catch (_: IOException) {
+                    false
+                } catch (_: RuntimeException) {
+                    false
+                } finally {
+                    try { sslSocket?.close() } catch (_: IOException) { }
+                    if (sslSocket == null) {
+                        try { socket?.close() } catch (_: IOException) { }
+                    }
+                }
+            }
+        }
+
         class DefaultDnsProbe : DnsProbeStrategy {
             override fun checkDns(resolver: String, network: Network?): Boolean {
-                val endpoint = parseDnsResolver(resolver)
+                val endpoint = parseEndpoint(resolver, DNS_PORT)
                 var socket: DatagramSocket? = null
 
                 return try {
@@ -1308,7 +1529,7 @@ class ConnectivityAndInternetAccess private constructor(
                     }
 
                     socket.soTimeout = DNS_TIMEOUT_MS
-                    socket.connect(InetSocketAddress(endpoint.host, endpoint.port))
+                    socket.connect(InetSocketAddress(resolveAddress(endpoint.host, network), endpoint.port))
                     socket.send(DatagramPacket(query, query.size))
 
                     val buffer = ByteArray(512)
@@ -1594,34 +1815,6 @@ class ConnectivityAndInternetAccess private constructor(
         private fun NetworkInfo?.isConnectedLegacy(): Boolean =
             this != null && isAvailable && isConnected
 
-        private fun isLegacyConnecting(
-            connectivityManager: ConnectivityManager
-        ): Boolean = legacyNetworks(connectivityManager).any { info ->
-            info != null &&
-                info.isAvailable &&
-                info.state == NetworkInfo.State.CONNECTING
-        }
-
-        private fun updateLegacyConnectingStallState(
-            connecting: Boolean
-        ): Boolean {
-            synchronized(connectionAttemptLock) {
-                if (!connecting) {
-                    legacyConnectingSinceElapsedRealtime = -1L
-                    return false
-                }
-
-                val now = SystemClock.elapsedRealtime()
-                if (legacyConnectingSinceElapsedRealtime < 0L) {
-                    legacyConnectingSinceElapsedRealtime = now
-                    return false
-                }
-
-                return now - legacyConnectingSinceElapsedRealtime >=
-                    CONNECTION_ATTEMPT_TIMEOUT_MS
-            }
-        }
-
         private fun isConnectionFast(type: Int, subType: Int): Boolean {
             if (type == ConnectivityManager.TYPE_WIFI ||
                 type == ConnectivityManager.TYPE_ETHERNET
@@ -1685,9 +1878,12 @@ class ConnectivityAndInternetAccess private constructor(
                  * rejects option-looking values and command/path punctuation while
                  * retaining IPv4, IPv6 zone identifiers and ordinary host names.
                  */
+                val processTarget = stripAddressBrackets(value)
                 require(
                     !value.startsWith("-") &&
-                        value.matches(Regex("[A-Za-z0-9._:%-]+"))
+                        !processTarget.startsWith("-") &&
+                        processTarget.isNotEmpty() &&
+                        processTarget.matches(Regex("[A-Za-z0-9._:%-]+"))
                 ) {
                     "Invalid ICMP target: $value"
                 }
@@ -1731,21 +1927,55 @@ class ConnectivityAndInternetAccess private constructor(
 
         private fun normalizeDnsResolvers(resolvers: List<String>): List<String> {
             val normalized = LinkedHashSet<String>()
-
             for (raw in resolvers) {
                 val value = raw.trim()
                 if (value.isNotEmpty()) {
-                    parseDnsResolver(value)
+                    parseEndpoint(value, DNS_PORT)
                     normalized += value
                 }
             }
+            return normalized.toList()
+        }
 
+        private fun normalizeEndpointTargets(
+            targets: List<String>,
+            defaultPort: Int,
+            argumentName: String
+        ): List<String> {
+            val normalized = LinkedHashSet<String>()
+            for (raw in targets) {
+                val value = raw.trim()
+                if (value.isNotEmpty()) {
+                    try {
+                        parseEndpoint(value, defaultPort)
+                    } catch (error: IllegalArgumentException) {
+                        throw IllegalArgumentException("$argumentName: ${error.message}", error)
+                    }
+                    normalized += value
+                }
+            }
+            return normalized.toList()
+        }
+
+        private fun normalizeNtpTargets(targets: List<String>): List<String> {
+            val normalized = LinkedHashSet<String>()
+            for (raw in targets) {
+                val value = raw.trim()
+                if (value.isEmpty()) {
+                    continue
+                }
+
+                val endpoint = parseEndpoint(value, NTP_PORT)
+                require(endpoint.port == NTP_PORT) {
+                    "NTP target must use port 123: $value"
+                }
+                normalized += endpoint.host
+            }
             return normalized.toList()
         }
 
         private fun isValidURL(address: String?): Boolean {
             address ?: throw IllegalArgumentException("url == null")
-
             return try {
                 val parsed = URL(address)
                 parsed.toURI()
@@ -1757,63 +1987,79 @@ class ConnectivityAndInternetAccess private constructor(
             }
         }
 
-        private fun dnsEndpointLabel(resolver: String): String {
-            val endpoint = parseDnsResolver(resolver)
-            val host = if (':' in endpoint.host) {
-                "[${endpoint.host}]"
+        private fun dnsEndpointLabel(resolver: String): String =
+            endpointLabel("dns", parseEndpoint(resolver, DNS_PORT))
+
+        private fun endpointLabel(scheme: String, endpoint: Endpoint): String =
+            "$scheme://${formatHost(endpoint.host)}:${endpoint.port}"
+
+        private fun formatHost(host: String): String =
+            if (':' in host) "[$host]" else host
+
+        private fun stripAddressBrackets(value: String): String {
+            val trimmed = value.trim()
+            return if (trimmed.startsWith("[") && trimmed.endsWith("]") && trimmed.length > 2) {
+                trimmed.substring(1, trimmed.length - 1)
             } else {
-                endpoint.host
+                trimmed
             }
-            return "dns://$host:${endpoint.port}"
         }
 
-        private fun parseDnsResolver(resolver: String): DnsResolver {
-            val value = resolver.trim()
-            require(value.isNotEmpty()) {
-                "Invalid DNS resolver"
+        private fun parseEndpoint(target: String, defaultPort: Int): Endpoint {
+            require(defaultPort in 1..65_535) {
+                "Invalid default port: $defaultPort"
             }
 
-            var host: String
-            var port = DNS_PORT
+            val value = target.trim()
+            require(value.isNotEmpty()) {
+                "Invalid endpoint"
+            }
+
+            val host: String
+            var port = defaultPort
 
             if (value.startsWith("[")) {
                 val closingBracket = value.indexOf(']')
-                require(closingBracket > 1) {
-                    "Invalid DNS resolver"
+                require(closingBracket > 1 && value.indexOf('[', 1) < 0) {
+                    "Invalid endpoint: $target"
                 }
 
                 host = value.substring(1, closingBracket).trim()
                 val remainder = value.substring(closingBracket + 1).trim()
                 if (remainder.isNotEmpty()) {
-                    require(remainder.startsWith(":")) {
-                        "Invalid DNS resolver"
+                    require(remainder.startsWith(":") && remainder.indexOf(':', 1) < 0) {
+                        "Invalid endpoint: $target"
                     }
                     port = parsePort(remainder.substring(1))
                 }
             } else {
+                require('[' !in value && ']' !in value) {
+                    "Invalid endpoint: $target"
+                }
+
                 val firstColon = value.indexOf(':')
                 val lastColon = value.lastIndexOf(':')
-
-                if (firstColon > 0 && firstColon == lastColon) {
+                if (firstColon >= 0 && firstColon == lastColon) {
                     host = value.substring(0, firstColon).trim()
                     port = parsePort(value.substring(firstColon + 1))
                 } else {
+                    // Multiple colons without brackets are a bare IPv6 literal.
                     host = value
                 }
             }
 
-            require(host.isNotEmpty() && port in 1..65_535) {
-                "Invalid DNS resolver"
+            require(host.isNotEmpty()) {
+                "Invalid endpoint: $target"
             }
 
-            return DnsResolver(host, port)
+            return Endpoint(host, port)
         }
 
         private fun parsePort(rawPort: String): Int {
             val port = rawPort.trim().toIntOrNull()
-                ?: throw IllegalArgumentException("Invalid DNS resolver port")
+                ?: throw IllegalArgumentException("Invalid endpoint port")
             require(port in 1..65_535) {
-                "Invalid DNS resolver port"
+                "Invalid endpoint port"
             }
             return port
         }
@@ -1842,13 +2088,11 @@ class ConnectivityAndInternetAccess private constructor(
                     }
                 }
             )
-
         private fun timeoutConnectionAttempt(attempt: ConnectionAttempt): Boolean {
             synchronized(connectionAttemptLock) {
                 if (attempt.closed) {
                     return false
                 }
-
                 attempt.closed = true
                 connectionAttemptQueue.remove(attempt)
                 connectionAttempts.updateAndGet { value ->
@@ -1858,7 +2102,6 @@ class ConnectivityAndInternetAccess private constructor(
                 return true
             }
         }
-
         private fun expireTimedOutConnectionAttempts() {
             val now = SystemClock.elapsedRealtime()
 
@@ -1886,6 +2129,34 @@ class ConnectivityAndInternetAccess private constructor(
             }
         }
 
+        private fun isLegacyConnecting(
+            connectivityManager: ConnectivityManager
+        ): Boolean = legacyNetworks(connectivityManager).any { info ->
+            info != null &&
+                info.isAvailable &&
+                info.state == NetworkInfo.State.CONNECTING
+        }
+
+        private fun updateLegacyConnectingStallState(
+            connecting: Boolean
+        ): Boolean {
+            synchronized(connectionAttemptLock) {
+                if (!connecting) {
+                    legacyConnectingSinceElapsedRealtime = -1L
+                    return false
+                }
+
+                val now = SystemClock.elapsedRealtime()
+                if (legacyConnectingSinceElapsedRealtime < 0L) {
+                    legacyConnectingSinceElapsedRealtime = now
+                    return false
+                }
+
+                return now - legacyConnectingSinceElapsedRealtime >=
+                    CONNECTION_ATTEMPT_TIMEOUT_MS
+            }
+        }
+
         private fun clearConnectionAttempts() {
             synchronized(connectionAttemptLock) {
                 connectionAttemptQueue.forEach { attempt ->
@@ -1903,11 +2174,10 @@ class ConnectivityAndInternetAccess private constructor(
             val operation: () -> Boolean
         )
 
-        private data class DnsResolver(
+        private data class Endpoint(
             val host: String,
             val port: Int
         )
-
         private class ConnectionAttempt(
             val startedAtElapsedRealtime: Long
         ) {
@@ -1980,4 +2250,3 @@ class ConnectivityAndInternetAccess private constructor(
         }
     }
 }
-

--- a/shared/network/src/androidMain/kotlin/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt
+++ b/shared/network/src/androidMain/kotlin/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt
@@ -230,7 +230,8 @@ class ConnectivityAndInternetAccess private constructor(
                         networkCapabilities: NetworkCapabilities
                     ) {
                         currentDefaultNetwork = network
-                        publish(networkStateFromCapabilities(networkCapabilities))
+                        publish(networkStateFromCapabilities(
+                            connectivityManager, networkCapabilities))
                     }
 
                     override fun onLost(network: Network) {
@@ -556,7 +557,11 @@ class ConnectivityAndInternetAccess private constructor(
             if (network == null) {
                 return false
             }
-            return manager(context).getNetworkCapabilities(network).isUsable()
+            val connectivityManager = manager(context)
+            return isEffectivelyUsable(
+                connectivityManager,
+                connectivityManager.getNetworkCapabilities(network)
+            )
         }
 
         @JvmStatic
@@ -680,7 +685,10 @@ class ConnectivityAndInternetAccess private constructor(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 val active = connectivityManager.activeNetwork
                 if (active != null &&
-                    connectivityManager.getNetworkCapabilities(active).isUsable()
+                    isEffectivelyUsable(
+                        connectivityManager,
+                        connectivityManager.getNetworkCapabilities(active)
+                    )
                 ) {
                     clearConnectionAttempts()
                     return true
@@ -690,7 +698,10 @@ class ConnectivityAndInternetAccess private constructor(
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 if (connectivityManager.allNetworks.any { network ->
-                        connectivityManager.getNetworkCapabilities(network).isUsable()
+                        isEffectivelyUsable(
+                            connectivityManager,
+                            connectivityManager.getNetworkCapabilities(network)
+                        )
                     }
                 ) {
                     clearConnectionAttempts()
@@ -706,30 +717,17 @@ class ConnectivityAndInternetAccess private constructor(
             return connected
         }
 
-        /**
-         * Cheap passive guard that ignores a dangling VPN-only default network.
-         * A VPN capability can remain present after its underlying Wi-Fi/mobile
-         * transport disappeared, so it must not make the app appear connected.
-         */
+        /** Returns whether a usable non-VPN network exists beneath the active path. */
+        @JvmStatic
+        fun hasUnderlyingNetwork(context: Context?): Boolean {
+            context ?: throw IllegalArgumentException("context == null")
+            return hasUsableNonVpnNetwork(manager(context))
+        }
+
+        /** Compatibility alias for [hasUnderlyingNetwork]. */
         @JvmStatic
         fun hasPhysicalNetwork(context: Context?): Boolean {
-            context ?: throw IllegalArgumentException("context == null")
-            val connectivityManager = manager(context)
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                return connectivityManager.allNetworks.any { network ->
-                    val capabilities = connectivityManager.getNetworkCapabilities(network)
-                    capabilities?.let { value ->
-                        value.isUsable() && (
-                            value.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
-                                value.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
-                                value.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
-                            )
-                    } == true
-                }
-            }
-
-            return connectivityManager.activeNetworkInfo.isConnectedLegacy()
+            return hasUnderlyingNetwork(context)
         }
 
         /** Cheap point-in-time snapshot of the application's default network. */
@@ -741,6 +739,7 @@ class ConnectivityAndInternetAccess private constructor(
                 val active = connectivityManager.activeNetwork
                     ?: return disconnectedNetworkState()
                 return networkStateFromCapabilities(
+                    connectivityManager,
                     connectivityManager.getNetworkCapabilities(active)
                 )
             }
@@ -788,9 +787,8 @@ class ConnectivityAndInternetAccess private constructor(
             }
 
             val capabilities = manager(context).getNetworkCapabilities(network)
-            return capabilities != null &&
-                capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-                capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            return isEffectivelyUsable(manager(context), capabilities) &&
+                capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) == true
         }
 
         /**
@@ -1735,9 +1733,10 @@ class ConnectivityAndInternetAccess private constructor(
         }
 
         private fun networkStateFromCapabilities(
+            connectivityManager: ConnectivityManager,
             capabilities: NetworkCapabilities?
         ): NetworkState {
-            val connected = capabilities.isUsable()
+            val connected = isEffectivelyUsable(connectivityManager, capabilities)
             val validated = connected &&
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 capabilities?.hasCapability(
@@ -1766,6 +1765,8 @@ class ConnectivityAndInternetAccess private constructor(
             context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
                 ?: throw IllegalStateException("ConnectivityManager unavailable")
 
+        // Low-level capability check only. Use isEffectivelyUsable() for
+        // application connectivity, including VPN underlying-network handling.
         private fun NetworkCapabilities?.isUsable(): Boolean {
             if (this == null ||
                 !hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
@@ -1775,6 +1776,34 @@ class ConnectivityAndInternetAccess private constructor(
 
             return Build.VERSION.SDK_INT < Build.VERSION_CODES.P ||
                 hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED)
+        }
+
+        private fun isEffectivelyUsable(
+            connectivityManager: ConnectivityManager,
+            capabilities: NetworkCapabilities?
+        ): Boolean {
+            if (!capabilities.isUsable()) return false
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP ||
+                !capabilities!!.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
+            ) return true
+            return hasUsableNonVpnNetwork(connectivityManager)
+        }
+
+        private fun hasUsableNonVpnNetwork(
+            connectivityManager: ConnectivityManager
+        ): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                return connectivityManager.activeNetworkInfo.isConnectedLegacy()
+            }
+            return connectivityManager.allNetworks.any { network ->
+                val capabilities = connectivityManager.getNetworkCapabilities(network)
+                capabilities.isUsable() &&
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                        capabilities!!.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
+                    } else {
+                        !capabilities!!.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
+                    }
+            }
         }
 
         private fun hasTransport(context: Context?, transport: Int): Boolean {
@@ -1878,7 +1907,10 @@ class ConnectivityAndInternetAccess private constructor(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 val active = connectivityManager.activeNetwork
                 if (active != null &&
-                    connectivityManager.getNetworkCapabilities(active).isUsable()
+                    isEffectivelyUsable(
+                        connectivityManager,
+                        connectivityManager.getNetworkCapabilities(active)
+                    )
                 ) {
                     return active
                 }
@@ -1886,7 +1918,10 @@ class ConnectivityAndInternetAccess private constructor(
             }
 
             return connectivityManager.allNetworks.firstOrNull { network ->
-                connectivityManager.getNetworkCapabilities(network).isUsable()
+                isEffectivelyUsable(
+                    connectivityManager,
+                    connectivityManager.getNetworkCapabilities(network)
+                )
             }
         }
 

--- a/shared/network/src/androidMain/kotlin/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt
+++ b/shared/network/src/androidMain/kotlin/net/i2p/android/router/util/ConnectivityAndInternetAccess.kt
@@ -706,6 +706,32 @@ class ConnectivityAndInternetAccess private constructor(
             return connected
         }
 
+        /**
+         * Cheap passive guard that ignores a dangling VPN-only default network.
+         * A VPN capability can remain present after its underlying Wi-Fi/mobile
+         * transport disappeared, so it must not make the app appear connected.
+         */
+        @JvmStatic
+        fun hasPhysicalNetwork(context: Context?): Boolean {
+            context ?: throw IllegalArgumentException("context == null")
+            val connectivityManager = manager(context)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                return connectivityManager.allNetworks.any { network ->
+                    val capabilities = connectivityManager.getNetworkCapabilities(network)
+                    capabilities?.let { value ->
+                        value.isUsable() && (
+                            value.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+                                value.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
+                                value.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+                            )
+                    } == true
+                }
+            }
+
+            return connectivityManager.activeNetworkInfo.isConnectedLegacy()
+        }
+
         /** Cheap point-in-time snapshot of the application's default network. */
         @JvmStatic
         fun snapshotNetworkState(context: Context): NetworkState {

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/di/ConnectivityKoinModule.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/di/ConnectivityKoinModule.kt
@@ -1,15 +1,16 @@
 package org.michaelbel.movies.network.connectivity.di
 
-import android.net.ConnectivityManager
-import androidx.core.content.ContextCompat
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 import org.michaelbel.movies.network.connectivity.NetworkManager
+import org.michaelbel.movies.network.connectivity.impl.BackendConnectivityInterceptor
+import org.michaelbel.movies.network.connectivity.impl.MoviesConnectivityMonitor
 import org.michaelbel.movies.network.connectivity.impl.NetworkManagerImpl
 
 actual val connectivityKoinModule = module {
-    single { ContextCompat.getSystemService(androidContext(), ConnectivityManager::class.java) as ConnectivityManager }
+    single { MoviesConnectivityMonitor(androidContext()) }
+    singleOf(::BackendConnectivityInterceptor)
     singleOf(::NetworkManagerImpl) { bind<NetworkManager>() }
 }

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/BackendConnectivityInterceptor.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/BackendConnectivityInterceptor.kt
@@ -1,25 +1,36 @@
 package org.michaelbel.movies.network.connectivity.impl
 
+import android.content.Context
+import net.i2p.android.router.util.ConnectivityAndInternetAccess
 import java.io.IOException
 import okhttp3.Interceptor
 import okhttp3.Response
-import org.michaelbel.movies.network.connectivity.MoviesConnectivityTargets
+import org.michaelbel.movies.network.connectivity.OfflineNetworkException
 
 /**
  * Observes transport failures from the real backend request. It never performs a
  * pre-flight check and never changes the response/error seen by Ktor.
  */
 class BackendConnectivityInterceptor(
+    context: Context,
     private val connectivityMonitor: MoviesConnectivityMonitor
 ) : Interceptor {
+    private val applicationContext = context.applicationContext ?: context
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
+
+        // Cheap local guard only. It does not perform DNS, TCP, TLS or HTTP probes.
+        if (!ConnectivityAndInternetAccess.isConnected(applicationContext)) {
+            throw OfflineNetworkException()
+        }
+
         return try {
             chain.proceed(request)
         } catch (failure: IOException) {
-            if (request.url.host in MoviesConnectivityTargets.backendDomains) {
-                connectivityMonitor.onBackendTransportFailure(request.url.host, failure)
-            }
+            // A response (including 4xx/5xx) is returned normally and never reaches here.
+            // Therefore this callback is reserved for transport-level failures.
+            connectivityMonitor.onBackendTransportFailure(request.url.host, failure)
             throw failure
         }
     }

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/BackendConnectivityInterceptor.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/BackendConnectivityInterceptor.kt
@@ -1,0 +1,26 @@
+package org.michaelbel.movies.network.connectivity.impl
+
+import java.io.IOException
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.michaelbel.movies.network.connectivity.MoviesConnectivityTargets
+
+/**
+ * Observes transport failures from the real backend request. It never performs a
+ * pre-flight check and never changes the response/error seen by Ktor.
+ */
+class BackendConnectivityInterceptor(
+    private val connectivityMonitor: MoviesConnectivityMonitor
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        return try {
+            chain.proceed(request)
+        } catch (failure: IOException) {
+            if (request.url.host in MoviesConnectivityTargets.backendDomains) {
+                connectivityMonitor.onBackendTransportFailure(request.url.host, failure)
+            }
+            throw failure
+        }
+    }
+}

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/BackendConnectivityInterceptor.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/BackendConnectivityInterceptor.kt
@@ -6,6 +6,7 @@ import java.io.IOException
 import okhttp3.Interceptor
 import okhttp3.Response
 import org.michaelbel.movies.network.connectivity.OfflineNetworkException
+import org.michaelbel.movies.network.connectivity.RemoteConnectivityPolicy
 
 /**
  * Observes transport failures from the real backend request. It never performs a
@@ -21,7 +22,11 @@ class BackendConnectivityInterceptor(
         val request = chain.request()
 
         // Cheap local guard only. It does not perform DNS, TCP, TLS or HTTP probes.
-        if (!ConnectivityAndInternetAccess.isConnected(applicationContext)) {
+        if (!RemoteConnectivityPolicy.canStartRemoteRequest(
+                isConnected = ConnectivityAndInternetAccess.isConnected(applicationContext),
+                hasPhysicalNetwork = ConnectivityAndInternetAccess.hasPhysicalNetwork(applicationContext)
+            )
+        ) {
             throw OfflineNetworkException()
         }
 

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/BackendConnectivityInterceptor.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/BackendConnectivityInterceptor.kt
@@ -27,6 +27,7 @@ class BackendConnectivityInterceptor(
                 hasPhysicalNetwork = ConnectivityAndInternetAccess.hasPhysicalNetwork(applicationContext)
             )
         ) {
+            connectivityMonitor.onNoNetworkForOperation()
             throw OfflineNetworkException()
         }
 

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/MoviesConnectivityMonitor.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/MoviesConnectivityMonitor.kt
@@ -77,6 +77,9 @@ class MoviesConnectivityMonitor(
     // own domains is collected separately immediately before these HTTPS probes.
     private val applicationConnectivity = ConnectivityAndInternetAccess.Builder()
         .setDnsResolvers(emptyList())
+        .setTcpTargets(emptyList())
+        .setNtpTargets(emptyList())
+        .setTlsTargets(emptyList())
         .setHosts(MoviesConnectivityTargets.backendProbeUrls)
         .build()
 
@@ -257,7 +260,7 @@ class MoviesConnectivityMonitor(
                             BackendDnsResult(
                                 domain = domain,
                                 resolved = addresses.isNotEmpty(),
-                                addresses = addresses.map(InetAddress::getHostAddress)
+                                addresses = addresses.mapNotNull(InetAddress::getHostAddress)
                             )
                         } catch (_: Exception) {
                             BackendDnsResult(domain, false, emptyList())

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/MoviesConnectivityMonitor.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/MoviesConnectivityMonitor.kt
@@ -1,15 +1,10 @@
 package org.michaelbel.movies.network.connectivity.impl
 
 import android.content.Context
-import android.net.ConnectivityManager
 import android.os.SystemClock
 import android.util.Log
 import java.io.Closeable
-import java.net.InetAddress
-import java.util.concurrent.Callable
 import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,22 +14,13 @@ import net.i2p.android.router.util.ConnectivityAndInternetAccess
 import org.michaelbel.movies.network.connectivity.ConnectivityFallbackPolicy
 import org.michaelbel.movies.network.connectivity.ConnectivityFallbackResult
 import org.michaelbel.movies.network.connectivity.ConnectivityTierResult
-import org.michaelbel.movies.network.connectivity.MoviesConnectivityTargets
 
 private const val TAG = "MoviesConnectivity"
 private const val DIAGNOSTIC_COOLDOWN_MS = 5_000L
-private const val BACKEND_DNS_DEADLINE_MS = 900L
-
-data class BackendDnsResult(
-    val domain: String,
-    val resolved: Boolean,
-    val addresses: List<String>
-)
 
 data class MoviesConnectivityDiagnostic(
     val failedBackendHost: String,
     val passiveState: ConnectivityAndInternetAccess.NetworkState,
-    val backendDns: List<BackendDnsResult>,
     val fallbackResult: ConnectivityFallbackResult?,
     val elapsedMilliseconds: Long
 )
@@ -50,18 +36,14 @@ data class MoviesConnectivityDiagnostic(
  * and therefore must never prevent the application from starting if Android rejects a network
  * callback registration or a vendor implementation throws while querying connectivity state.
  *
- * Diagnostic order after a transport failure:
- *  1. Resolve only domains used by Movies on the active Android Network.
- *  2. Probe only Movies/TMDb/Gravatar HTTPS destinations.
- *  3. Only if every application destination fails, run the generic DNS/HTTPS fallback from
- *     ConnectivityAndInternetAccess.
+ * After a transport failure reported by Ktor or a background downloader, the active generic
+ * diagnostic is deliberately deferred until this point. It distinguishes a general Internet
+ * outage from a failure of the original operation without adding pre-flight probes to success.
  */
 class MoviesConnectivityMonitor(
     context: Context
 ) : Closeable {
     private val applicationContext = context.applicationContext ?: context
-    private val connectivityManager =
-        applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
 
     private val networkStateMutable = MutableStateFlow(snapshotNetworkStateSafely())
     val networkState: StateFlow<ConnectivityAndInternetAccess.NetworkState> =
@@ -73,17 +55,7 @@ class MoviesConnectivityMonitor(
 
     private val fallbackPolicy = ConnectivityFallbackPolicy()
 
-    // App-specific tier deliberately disables the gist's generic DNS phase. DNS for the app's
-    // own domains is collected separately immediately before these HTTPS probes.
-    private val applicationConnectivity = ConnectivityAndInternetAccess.Builder()
-        .setDnsResolvers(emptyList())
-        .setTcpTargets(emptyList())
-        .setNtpTargets(emptyList())
-        .setTlsTargets(emptyList())
-        .setHosts(MoviesConnectivityTargets.backendProbeUrls)
-        .build()
-
-    // Untouched gist defaults: effective/system DNS -> public DNS -> generic HTTPS hosts.
+    // Untouched Gist defaults: effective/system DNS -> public DNS -> TCP/NTP/TLS/HTTPS.
     private val genericConnectivity = ConnectivityAndInternetAccess.Builder().build()
 
     private val diagnosticExecutor = Executors.newSingleThreadExecutor { runnable ->
@@ -172,7 +144,6 @@ class MoviesConnectivityMonitor(
             val diagnostic = MoviesConnectivityDiagnostic(
                 failedBackendHost = failedHost,
                 passiveState = passive,
-                backendDns = emptyList(),
                 fallbackResult = null,
                 elapsedMilliseconds = SystemClock.elapsedRealtime() - started
             )
@@ -181,20 +152,9 @@ class MoviesConnectivityMonitor(
             return
         }
 
-        val backendDns = resolveBackendDomains()
-        Log.d(
-            TAG,
-            "backend DNS: " + backendDns.joinToString { result ->
-                "${result.domain}=${if (result.resolved) "ok" else "failed"}"
-            }
-        )
-
         val fallbackResult = fallbackPolicy.diagnose(
-            applicationProbe = {
-                applicationConnectivity.checkInternetBlocking(applicationContext).toTierResult()
-            },
+            failedTarget = failedHost,
             generalProbe = {
-                // This lambda is not invoked unless the complete application tier failed.
                 genericConnectivity.checkInternetBlocking(applicationContext).toTierResult()
             }
         )
@@ -202,91 +162,23 @@ class MoviesConnectivityMonitor(
         val diagnostic = MoviesConnectivityDiagnostic(
             failedBackendHost = failedHost,
             passiveState = passive,
-            backendDns = backendDns,
             fallbackResult = fallbackResult,
             elapsedMilliseconds = SystemClock.elapsedRealtime() - started
         )
         lastDiagnosticMutable.value = diagnostic
 
         when {
-            fallbackResult.applicationTier.reachable -> Log.w(
-                TAG,
-                "diagnosis: Movies endpoints are reachable via " +
-                    "${fallbackResult.applicationTier.reachedEndpoint}; original request failure " +
-                    "was transient or request-specific"
-            )
-
             fallbackResult.generalTier?.reachable == true -> Log.w(
                 TAG,
                 "diagnosis: generic Internet works via " +
-                    "${fallbackResult.generalTier.reachedEndpoint}, but every Movies endpoint " +
-                    "probe failed"
+                    "${fallbackResult.generalTier.reachedEndpoint}; failed backend=$failedHost " +
+                    "is likely target/service-specific or transient"
             )
 
             else -> Log.w(
                 TAG,
                 "diagnosis: Movies endpoints failed and generic Internet fallback also failed"
             )
-        }
-    }
-
-    private fun resolveBackendDomains(): List<BackendDnsResult> {
-        val network = try {
-            connectivityManager?.activeNetwork
-        } catch (runtime: RuntimeException) {
-            Log.e(TAG, "unable to obtain active network for backend DNS diagnostics", runtime)
-            null
-        }
-
-        if (network == null) {
-            return MoviesConnectivityTargets.backendDomains.map { domain ->
-                BackendDnsResult(domain, false, emptyList())
-            }
-        }
-
-        val dnsExecutor = Executors.newFixedThreadPool(
-            MoviesConnectivityTargets.backendDomains.size.coerceAtLeast(1)
-        ) { runnable ->
-            Thread(runnable, "movies-backend-dns").apply { isDaemon = true }
-        }
-        val deadline = SystemClock.elapsedRealtime() + BACKEND_DNS_DEADLINE_MS
-
-        try {
-            val futures = MoviesConnectivityTargets.backendDomains.associateWith { domain ->
-                dnsExecutor.submit(
-                    Callable {
-                        try {
-                            val addresses: Array<InetAddress> = network.getAllByName(domain)
-                            BackendDnsResult(
-                                domain = domain,
-                                resolved = addresses.isNotEmpty(),
-                                addresses = addresses.mapNotNull(InetAddress::getHostAddress)
-                            )
-                        } catch (_: Exception) {
-                            BackendDnsResult(domain, false, emptyList())
-                        }
-                    }
-                )
-            }
-
-            return MoviesConnectivityTargets.backendDomains.map { domain ->
-                val remaining = deadline - SystemClock.elapsedRealtime()
-                if (remaining <= 0L) {
-                    futures.getValue(domain).cancel(true)
-                    BackendDnsResult(domain, false, emptyList())
-                } else {
-                    try {
-                        futures.getValue(domain).get(remaining, TimeUnit.MILLISECONDS)
-                    } catch (_: TimeoutException) {
-                        futures.getValue(domain).cancel(true)
-                        BackendDnsResult(domain, false, emptyList())
-                    } catch (_: Exception) {
-                        BackendDnsResult(domain, false, emptyList())
-                    }
-                }
-            }
-        } finally {
-            dnsExecutor.shutdownNow()
         }
     }
 

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/MoviesConnectivityMonitor.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/MoviesConnectivityMonitor.kt
@@ -1,0 +1,306 @@
+package org.michaelbel.movies.network.connectivity.impl
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.os.SystemClock
+import android.util.Log
+import java.io.Closeable
+import java.net.InetAddress
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import net.i2p.android.router.util.ConnectivityAndInternetAccess
+import org.michaelbel.movies.network.connectivity.ConnectivityFallbackPolicy
+import org.michaelbel.movies.network.connectivity.ConnectivityFallbackResult
+import org.michaelbel.movies.network.connectivity.ConnectivityTierResult
+import org.michaelbel.movies.network.connectivity.MoviesConnectivityTargets
+
+private const val TAG = "MoviesConnectivity"
+private const val DIAGNOSTIC_COOLDOWN_MS = 5_000L
+private const val BACKEND_DNS_DEADLINE_MS = 900L
+
+data class BackendDnsResult(
+    val domain: String,
+    val resolved: Boolean,
+    val addresses: List<String>
+)
+
+data class MoviesConnectivityDiagnostic(
+    val failedBackendHost: String,
+    val passiveState: ConnectivityAndInternetAccess.NetworkState,
+    val backendDns: List<BackendDnsResult>,
+    val fallbackResult: ConnectivityFallbackResult?,
+    val elapsedMilliseconds: Long
+)
+
+/**
+ * Application-level network observer and failure diagnostic.
+ *
+ * Normal operation is passive: one observer follows Android's actual default network and
+ * generates no DNS or HTTP traffic. Active diagnostics are started only after OkHttp/Ktor
+ * reports a transport IOException. The real application request is never gated or replaced.
+ *
+ * The observer is deliberately fail-safe. Connectivity diagnostics are auxiliary functionality
+ * and therefore must never prevent the application from starting if Android rejects a network
+ * callback registration or a vendor implementation throws while querying connectivity state.
+ *
+ * Diagnostic order after a transport failure:
+ *  1. Resolve only domains used by Movies on the active Android Network.
+ *  2. Probe only Movies/TMDb/Gravatar HTTPS destinations.
+ *  3. Only if every application destination fails, run the generic DNS/HTTPS fallback from
+ *     ConnectivityAndInternetAccess.
+ */
+class MoviesConnectivityMonitor(
+    context: Context
+) : Closeable {
+    private val applicationContext = context.applicationContext ?: context
+    private val connectivityManager =
+        applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+
+    private val networkStateMutable = MutableStateFlow(snapshotNetworkStateSafely())
+    val networkState: StateFlow<ConnectivityAndInternetAccess.NetworkState> =
+        networkStateMutable.asStateFlow()
+
+    private val lastDiagnosticMutable = MutableStateFlow<MoviesConnectivityDiagnostic?>(null)
+    val lastDiagnostic: StateFlow<MoviesConnectivityDiagnostic?> =
+        lastDiagnosticMutable.asStateFlow()
+
+    private val fallbackPolicy = ConnectivityFallbackPolicy()
+
+    // App-specific tier deliberately disables the gist's generic DNS phase. DNS for the app's
+    // own domains is collected separately immediately before these HTTPS probes.
+    private val applicationConnectivity = ConnectivityAndInternetAccess.Builder()
+        .setDnsResolvers(emptyList())
+        .setHosts(MoviesConnectivityTargets.backendProbeUrls)
+        .build()
+
+    // Untouched gist defaults: effective/system DNS -> public DNS -> generic HTTPS hosts.
+    private val genericConnectivity = ConnectivityAndInternetAccess.Builder().build()
+
+    private val diagnosticExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "movies-connectivity-diagnostic").apply { isDaemon = true }
+    }
+    private val diagnosticInFlight = AtomicBoolean(false)
+    private val lastDiagnosticStartedAt = AtomicLong(Long.MIN_VALUE)
+    private val closed = AtomicBoolean(false)
+
+    private val observer: Closeable? = createObserverSafely()
+
+    private fun snapshotNetworkStateSafely(): ConnectivityAndInternetAccess.NetworkState {
+        return try {
+            ConnectivityAndInternetAccess.snapshotNetworkState(applicationContext)
+        } catch (runtime: RuntimeException) {
+            Log.e(TAG, "unable to read initial network state; continuing without blocking startup", runtime)
+            disconnectedFallbackState()
+        }
+    }
+
+    private fun createObserverSafely(): Closeable? {
+        return try {
+            ConnectivityAndInternetAccess.observeNetwork(applicationContext) { state ->
+                networkStateMutable.value = state
+                Log.d(
+                    TAG,
+                    "default-network connected=${state.connected}, " +
+                        "validated=${state.internetValidated}, " +
+                        "captivePortal=${state.captivePortalDetected}"
+                )
+            }
+        } catch (runtime: RuntimeException) {
+            Log.e(
+                TAG,
+                "unable to register default-network observer; app will continue without passive updates",
+                runtime
+            )
+            null
+        }
+    }
+
+    private fun disconnectedFallbackState() = ConnectivityAndInternetAccess.NetworkState(
+        connected = false,
+        internetValidated = false,
+        captivePortalDetected = false,
+        observedAtElapsedRealtime = SystemClock.elapsedRealtime()
+    )
+
+    fun onBackendTransportFailure(failedHost: String, failure: Throwable) {
+        if (closed.get()) return
+
+        val now = SystemClock.elapsedRealtime()
+        val previous = lastDiagnosticStartedAt.get()
+        if (previous != Long.MIN_VALUE && now - previous < DIAGNOSTIC_COOLDOWN_MS) {
+            Log.d(TAG, "diagnostic skipped (cooldown), backend=$failedHost")
+            return
+        }
+        if (!diagnosticInFlight.compareAndSet(false, true)) {
+            Log.d(TAG, "diagnostic skipped (already running), backend=$failedHost")
+            return
+        }
+        lastDiagnosticStartedAt.set(now)
+
+        Log.w(
+            TAG,
+            "backend transport failure host=$failedHost, " +
+                "type=${failure.javaClass.simpleName}; starting app-first diagnosis"
+        )
+
+        diagnosticExecutor.execute {
+            try {
+                runDiagnostic(failedHost)
+            } catch (runtime: RuntimeException) {
+                Log.e(TAG, "connectivity diagnostic failed", runtime)
+            } finally {
+                diagnosticInFlight.set(false)
+            }
+        }
+    }
+
+    private fun runDiagnostic(failedHost: String) {
+        val started = SystemClock.elapsedRealtime()
+        val passive = networkStateMutable.value
+
+        if (!passive.connected) {
+            val diagnostic = MoviesConnectivityDiagnostic(
+                failedBackendHost = failedHost,
+                passiveState = passive,
+                backendDns = emptyList(),
+                fallbackResult = null,
+                elapsedMilliseconds = SystemClock.elapsedRealtime() - started
+            )
+            lastDiagnosticMutable.value = diagnostic
+            Log.w(TAG, "diagnosis: Android default network is offline; active probes skipped")
+            return
+        }
+
+        val backendDns = resolveBackendDomains()
+        Log.d(
+            TAG,
+            "backend DNS: " + backendDns.joinToString { result ->
+                "${result.domain}=${if (result.resolved) "ok" else "failed"}"
+            }
+        )
+
+        val fallbackResult = fallbackPolicy.diagnose(
+            applicationProbe = {
+                applicationConnectivity.checkInternetBlocking(applicationContext).toTierResult()
+            },
+            generalProbe = {
+                // This lambda is not invoked unless the complete application tier failed.
+                genericConnectivity.checkInternetBlocking(applicationContext).toTierResult()
+            }
+        )
+
+        val diagnostic = MoviesConnectivityDiagnostic(
+            failedBackendHost = failedHost,
+            passiveState = passive,
+            backendDns = backendDns,
+            fallbackResult = fallbackResult,
+            elapsedMilliseconds = SystemClock.elapsedRealtime() - started
+        )
+        lastDiagnosticMutable.value = diagnostic
+
+        when {
+            fallbackResult.applicationTier.reachable -> Log.w(
+                TAG,
+                "diagnosis: Movies endpoints are reachable via " +
+                    "${fallbackResult.applicationTier.reachedEndpoint}; original request failure " +
+                    "was transient or request-specific"
+            )
+
+            fallbackResult.generalTier?.reachable == true -> Log.w(
+                TAG,
+                "diagnosis: generic Internet works via " +
+                    "${fallbackResult.generalTier.reachedEndpoint}, but every Movies endpoint " +
+                    "probe failed"
+            )
+
+            else -> Log.w(
+                TAG,
+                "diagnosis: Movies endpoints failed and generic Internet fallback also failed"
+            )
+        }
+    }
+
+    private fun resolveBackendDomains(): List<BackendDnsResult> {
+        val network = try {
+            connectivityManager?.activeNetwork
+        } catch (runtime: RuntimeException) {
+            Log.e(TAG, "unable to obtain active network for backend DNS diagnostics", runtime)
+            null
+        }
+
+        if (network == null) {
+            return MoviesConnectivityTargets.backendDomains.map { domain ->
+                BackendDnsResult(domain, false, emptyList())
+            }
+        }
+
+        val dnsExecutor = Executors.newFixedThreadPool(
+            MoviesConnectivityTargets.backendDomains.size.coerceAtLeast(1)
+        ) { runnable ->
+            Thread(runnable, "movies-backend-dns").apply { isDaemon = true }
+        }
+        val deadline = SystemClock.elapsedRealtime() + BACKEND_DNS_DEADLINE_MS
+
+        try {
+            val futures = MoviesConnectivityTargets.backendDomains.associateWith { domain ->
+                dnsExecutor.submit(
+                    Callable {
+                        try {
+                            val addresses: Array<InetAddress> = network.getAllByName(domain)
+                            BackendDnsResult(
+                                domain = domain,
+                                resolved = addresses.isNotEmpty(),
+                                addresses = addresses.map(InetAddress::getHostAddress)
+                            )
+                        } catch (_: Exception) {
+                            BackendDnsResult(domain, false, emptyList())
+                        }
+                    }
+                )
+            }
+
+            return MoviesConnectivityTargets.backendDomains.map { domain ->
+                val remaining = deadline - SystemClock.elapsedRealtime()
+                if (remaining <= 0L) {
+                    futures.getValue(domain).cancel(true)
+                    BackendDnsResult(domain, false, emptyList())
+                } else {
+                    try {
+                        futures.getValue(domain).get(remaining, TimeUnit.MILLISECONDS)
+                    } catch (_: TimeoutException) {
+                        futures.getValue(domain).cancel(true)
+                        BackendDnsResult(domain, false, emptyList())
+                    } catch (_: Exception) {
+                        BackendDnsResult(domain, false, emptyList())
+                    }
+                }
+            }
+        } finally {
+            dnsExecutor.shutdownNow()
+        }
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        try {
+            observer?.close()
+        } catch (runtime: RuntimeException) {
+            Log.w(TAG, "default-network observer cleanup failed", runtime)
+        }
+        diagnosticExecutor.shutdownNow()
+    }
+
+    private fun ConnectivityAndInternetAccess.InternetResult.toTierResult() =
+        ConnectivityTierResult(
+            reachable = reachable,
+            reachedEndpoint = reachedHost,
+            attemptedEndpoints = attemptedHosts
+        )
+}

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/MoviesConnectivityMonitor.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/MoviesConnectivityMonitor.kt
@@ -7,9 +7,13 @@ import java.io.Closeable
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import net.i2p.android.router.util.ConnectivityAndInternetAccess
 import org.michaelbel.movies.network.connectivity.ConnectivityFallbackPolicy
 import org.michaelbel.movies.network.connectivity.ConnectivityFallbackResult
@@ -18,6 +22,16 @@ import org.michaelbel.movies.network.connectivity.RemoteConnectivityPolicy
 
 private const val TAG = "MoviesConnectivity"
 private const val DIAGNOSTIC_COOLDOWN_MS = 5_000L
+private const val USER_MESSAGE_COOLDOWN_MS = 5_000L
+
+enum class ConnectivityUiEvent {
+    NetworkLost,
+    NetworkRecovered,
+    CaptivePortal,
+    NoNetworkForOperation,
+    InternetUnavailable,
+    BackendUnavailable
+}
 
 data class MoviesConnectivityDiagnostic(
     val failedBackendHost: String,
@@ -54,6 +68,11 @@ class MoviesConnectivityMonitor(
     val lastDiagnostic: StateFlow<MoviesConnectivityDiagnostic?> =
         lastDiagnosticMutable.asStateFlow()
 
+    private val uiEventsMutable = MutableSharedFlow<ConnectivityUiEvent>(extraBufferCapacity = 8)
+    val uiEvents: SharedFlow<ConnectivityUiEvent> = uiEventsMutable.asSharedFlow()
+    private val lastUiEventAt = ConcurrentHashMap<String, AtomicLong>()
+    private var previousState: ConnectivityAndInternetAccess.NetworkState = networkStateMutable.value
+
     private val fallbackPolicy = ConnectivityFallbackPolicy()
 
     // Untouched Gist defaults: effective/system DNS -> public DNS -> TCP/NTP/TLS/HTTPS.
@@ -82,6 +101,8 @@ class MoviesConnectivityMonitor(
             ConnectivityAndInternetAccess.observeNetwork(applicationContext) { state ->
                 val normalizedState = normalizeNetworkState(state)
                 networkStateMutable.value = normalizedState
+                publishUiEvents(previousState, normalizedState)
+                previousState = normalizedState
                 Log.d(
                     TAG,
                     "default-network connected=${normalizedState.connected}, " +
@@ -198,6 +219,47 @@ class MoviesConnectivityMonitor(
                 TAG,
                 "diagnosis: Movies endpoints failed and generic Internet fallback also failed"
             )
+        }
+
+        emitUiEvent(
+            if (fallbackResult.generalTier?.reachable == true) {
+                ConnectivityUiEvent.BackendUnavailable
+            } else {
+                ConnectivityUiEvent.InternetUnavailable
+            }
+        )
+    }
+
+    fun onNoNetworkForOperation() {
+        emitUiEvent(ConnectivityUiEvent.NoNetworkForOperation)
+    }
+
+    private fun publishUiEvents(
+        previous: ConnectivityAndInternetAccess.NetworkState,
+        current: ConnectivityAndInternetAccess.NetworkState
+    ) {
+        if (previous.connected && !current.connected) {
+            emitUiEvent(ConnectivityUiEvent.NetworkLost)
+        } else if (!previous.connected && current.connected) {
+            emitUiEvent(ConnectivityUiEvent.NetworkRecovered)
+        }
+        if (!previous.captivePortalDetected && current.captivePortalDetected) {
+            emitUiEvent(ConnectivityUiEvent.CaptivePortal)
+        }
+    }
+
+    private fun emitUiEvent(event: ConnectivityUiEvent) {
+        val now = SystemClock.elapsedRealtime()
+        val key = when (event) {
+            ConnectivityUiEvent.NetworkLost,
+            ConnectivityUiEvent.NoNetworkForOperation -> "offline"
+            else -> event.name
+        }
+        val last = lastUiEventAt.getOrPut(key) { AtomicLong(Long.MIN_VALUE) }
+        val previous = last.get()
+        if (previous != Long.MIN_VALUE && now - previous < USER_MESSAGE_COOLDOWN_MS) return
+        if (last.compareAndSet(previous, now)) {
+            uiEventsMutable.tryEmit(event)
         }
     }
 

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/MoviesConnectivityMonitor.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/MoviesConnectivityMonitor.kt
@@ -14,6 +14,7 @@ import net.i2p.android.router.util.ConnectivityAndInternetAccess
 import org.michaelbel.movies.network.connectivity.ConnectivityFallbackPolicy
 import org.michaelbel.movies.network.connectivity.ConnectivityFallbackResult
 import org.michaelbel.movies.network.connectivity.ConnectivityTierResult
+import org.michaelbel.movies.network.connectivity.RemoteConnectivityPolicy
 
 private const val TAG = "MoviesConnectivity"
 private const val DIAGNOSTIC_COOLDOWN_MS = 5_000L
@@ -69,7 +70,7 @@ class MoviesConnectivityMonitor(
 
     private fun snapshotNetworkStateSafely(): ConnectivityAndInternetAccess.NetworkState {
         return try {
-            ConnectivityAndInternetAccess.snapshotNetworkState(applicationContext)
+            normalizeNetworkState(ConnectivityAndInternetAccess.snapshotNetworkState(applicationContext))
         } catch (runtime: RuntimeException) {
             Log.e(TAG, "unable to read initial network state; continuing without blocking startup", runtime)
             disconnectedFallbackState()
@@ -79,12 +80,13 @@ class MoviesConnectivityMonitor(
     private fun createObserverSafely(): Closeable? {
         return try {
             ConnectivityAndInternetAccess.observeNetwork(applicationContext) { state ->
-                networkStateMutable.value = state
+                val normalizedState = normalizeNetworkState(state)
+                networkStateMutable.value = normalizedState
                 Log.d(
                     TAG,
-                    "default-network connected=${state.connected}, " +
-                        "validated=${state.internetValidated}, " +
-                        "captivePortal=${state.captivePortalDetected}"
+                    "default-network connected=${normalizedState.connected}, " +
+                        "validated=${normalizedState.internetValidated}, " +
+                        "captivePortal=${normalizedState.captivePortalDetected}"
                 )
             }
         } catch (runtime: RuntimeException) {
@@ -103,6 +105,23 @@ class MoviesConnectivityMonitor(
         captivePortalDetected = false,
         observedAtElapsedRealtime = SystemClock.elapsedRealtime()
     )
+
+    private fun normalizeNetworkState(
+        state: ConnectivityAndInternetAccess.NetworkState
+    ): ConnectivityAndInternetAccess.NetworkState {
+        val hasPhysicalNetwork = try {
+            ConnectivityAndInternetAccess.hasPhysicalNetwork(applicationContext)
+        } catch (runtime: RuntimeException) {
+            Log.w(TAG, "unable to verify physical network; treating state as offline", runtime)
+            false
+        }
+        return state.copy(
+            connected = RemoteConnectivityPolicy.canStartRemoteRequest(
+                isConnected = state.connected,
+                hasPhysicalNetwork = hasPhysicalNetwork
+            )
+        )
+    }
 
     fun onBackendTransportFailure(failedHost: String, failure: Throwable) {
         if (closed.get()) return

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/NetworkManagerImpl.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/connectivity/impl/NetworkManagerImpl.kt
@@ -1,40 +1,21 @@
 package org.michaelbel.movies.network.connectivity.impl
 
-import android.net.ConnectivityManager
-import android.net.Network
-import android.net.NetworkCapabilities
-import android.net.NetworkRequest
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import org.michaelbel.movies.network.connectivity.NetworkManager
 import org.michaelbel.movies.network.connectivity.NetworkStatus
 
 class NetworkManagerImpl(
-    private val connectivityManager: ConnectivityManager
-): NetworkManager {
-    override val status: Flow<NetworkStatus> = callbackFlow {
-        val networkCallback = object: ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                trySend(NetworkStatus.Available)
-            }
-
-            override fun onLost(network: Network) {
-                trySend(NetworkStatus.Unavailable)
-            }
-
-            override fun onUnavailable() {
-                trySend(NetworkStatus.Unavailable)
+    connectivityMonitor: MoviesConnectivityMonitor
+) : NetworkManager {
+    override val status: Flow<NetworkStatus> = connectivityMonitor.networkState
+        .map { state ->
+            if (state.connected) {
+                NetworkStatus.Available
+            } else {
+                NetworkStatus.Unavailable
             }
         }
-
-        val request = NetworkRequest.Builder()
-            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-            .build()
-        connectivityManager.registerNetworkCallback(request, networkCallback)
-
-        awaitClose {
-            connectivityManager.unregisterNetworkCallback(networkCallback)
-        }
-    }
+        .distinctUntilChanged()
 }

--- a/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/ktor/di/KtorKoinModule.android.kt
+++ b/shared/network/src/androidMain/kotlin/org/michaelbel/movies/network/ktor/di/KtorKoinModule.android.kt
@@ -15,6 +15,8 @@ import org.koin.dsl.module
 import org.michaelbel.movies.network.chuckerKoinModule
 import org.michaelbel.movies.network.config.TMDB_API_ENDPOINT
 import org.michaelbel.movies.network.config.tmdbApiKey
+import org.michaelbel.movies.network.connectivity.di.connectivityKoinModule
+import org.michaelbel.movies.network.connectivity.impl.BackendConnectivityInterceptor
 import org.michaelbel.movies.network.httpLoggingInterceptorKoinModule
 
 private const val REQUEST_TIMEOUT_MILLIS = 10_000L
@@ -24,6 +26,7 @@ private const val CONNECT_TIMEOUT_MILLIS = 10_000L
 
 actual val ktorKoinModule = module {
     includes(
+        connectivityKoinModule,
         chuckerKoinModule,
         httpLoggingInterceptorKoinModule
     )
@@ -47,6 +50,9 @@ actual val ktorKoinModule = module {
             engine {
                 clientCacheSize = HTTP_CACHE_SIZE_BYTES
                 config {
+                    // Observe only real backend transport failures. The interceptor rethrows
+                    // the original IOException immediately and diagnostics run asynchronously.
+                    addInterceptor(get<BackendConnectivityInterceptor>())
                     addInterceptor(get<ChuckerInterceptor>())
                     addInterceptor(get<HttpLoggingInterceptor>())
                 }

--- a/shared/network/src/commonMain/kotlin/org/michaelbel/movies/network/connectivity/ConnectivityFallbackPolicy.kt
+++ b/shared/network/src/commonMain/kotlin/org/michaelbel/movies/network/connectivity/ConnectivityFallbackPolicy.kt
@@ -1,0 +1,65 @@
+package org.michaelbel.movies.network.connectivity
+
+/**
+ * Network destinations actually used by Movies. Diagnostics always try these first.
+ * Generic Internet destinations from ConnectivityAndInternetAccess are deliberately
+ * reserved for fallback diagnosis after this complete application tier has failed.
+ */
+object MoviesConnectivityTargets {
+    val backendDomains: List<String> = listOf(
+        "api.themoviedb.org",
+        "image.tmdb.org",
+        "themoviedb.org",
+        "www.themoviedb.org",
+        "www.gravatar.com"
+    )
+
+    val backendProbeUrls: List<String> = listOf(
+        "https://api.themoviedb.org/3/",
+        "https://image.tmdb.org/",
+        "https://themoviedb.org/",
+        "https://www.themoviedb.org/",
+        "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=404"
+    )
+}
+
+data class ConnectivityTierResult(
+    val reachable: Boolean,
+    val reachedEndpoint: String?,
+    val attemptedEndpoints: List<String>
+)
+
+data class ConnectivityFallbackResult(
+    val applicationTier: ConnectivityTierResult,
+    val generalTier: ConnectivityTierResult?
+) {
+    val reachable: Boolean
+        get() = applicationTier.reachable || generalTier?.reachable == true
+
+    val usedGeneralFallback: Boolean
+        get() = generalTier != null
+}
+
+/**
+ * Encodes the application-first invariant independently of Android and networking APIs,
+ * so the fallback order can be unit-tested without performing network I/O.
+ */
+class ConnectivityFallbackPolicy {
+    fun diagnose(
+        applicationProbe: () -> ConnectivityTierResult,
+        generalProbe: () -> ConnectivityTierResult
+    ): ConnectivityFallbackResult {
+        val application = applicationProbe()
+        if (application.reachable) {
+            return ConnectivityFallbackResult(
+                applicationTier = application,
+                generalTier = null
+            )
+        }
+
+        return ConnectivityFallbackResult(
+            applicationTier = application,
+            generalTier = generalProbe()
+        )
+    }
+}

--- a/shared/network/src/commonMain/kotlin/org/michaelbel/movies/network/connectivity/ConnectivityFallbackPolicy.kt
+++ b/shared/network/src/commonMain/kotlin/org/michaelbel/movies/network/connectivity/ConnectivityFallbackPolicy.kt
@@ -1,28 +1,5 @@
 package org.michaelbel.movies.network.connectivity
 
-/**
- * Network destinations actually used by Movies. Diagnostics always try these first.
- * Generic Internet destinations from ConnectivityAndInternetAccess are deliberately
- * reserved for fallback diagnosis after this complete application tier has failed.
- */
-object MoviesConnectivityTargets {
-    val backendDomains: List<String> = listOf(
-        "api.themoviedb.org",
-        "image.tmdb.org",
-        "themoviedb.org",
-        "www.themoviedb.org",
-        "www.gravatar.com"
-    )
-
-    val backendProbeUrls: List<String> = listOf(
-        "https://api.themoviedb.org/3/",
-        "https://image.tmdb.org/",
-        "https://themoviedb.org/",
-        "https://www.themoviedb.org/",
-        "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=404"
-    )
-}
-
 data class ConnectivityTierResult(
     val reachable: Boolean,
     val reachedEndpoint: String?,
@@ -41,24 +18,20 @@ data class ConnectivityFallbackResult(
 }
 
 /**
- * Encodes the application-first invariant independently of Android and networking APIs,
- * so the fallback order can be unit-tested without performing network I/O.
+ * Encodes the post-failure diagnostic invariant independently of Android and networking APIs:
+ * the failed real target is recorded, then one generic active Internet diagnostic runs.
  */
 class ConnectivityFallbackPolicy {
     fun diagnose(
-        applicationProbe: () -> ConnectivityTierResult,
+        failedTarget: String,
         generalProbe: () -> ConnectivityTierResult
     ): ConnectivityFallbackResult {
-        val application = applicationProbe()
-        if (application.reachable) {
-            return ConnectivityFallbackResult(
-                applicationTier = application,
-                generalTier = null
-            )
-        }
-
         return ConnectivityFallbackResult(
-            applicationTier = application,
+            applicationTier = ConnectivityTierResult(
+                reachable = false,
+                reachedEndpoint = null,
+                attemptedEndpoints = listOf(failedTarget)
+            ),
             generalTier = generalProbe()
         )
     }

--- a/shared/network/src/commonMain/kotlin/org/michaelbel/movies/network/connectivity/NetworkStatus.kt
+++ b/shared/network/src/commonMain/kotlin/org/michaelbel/movies/network/connectivity/NetworkStatus.kt
@@ -4,3 +4,8 @@ sealed interface NetworkStatus {
     data object Available: NetworkStatus
     data object Unavailable: NetworkStatus
 }
+
+/** Raised when a network operation is requested while Android has no usable network. */
+class OfflineNetworkException : IllegalStateException(
+    "No usable network is available for this operation"
+)

--- a/shared/network/src/commonMain/kotlin/org/michaelbel/movies/network/connectivity/RemoteConnectivityPolicy.kt
+++ b/shared/network/src/commonMain/kotlin/org/michaelbel/movies/network/connectivity/RemoteConnectivityPolicy.kt
@@ -1,0 +1,14 @@
+package org.michaelbel.movies.network.connectivity
+
+/**
+ * Policy for starting a new remote operation.
+ *
+ * Android's connected signal can be positive for a VPN-only network, so both the
+ * generic connected state and a real Wi-Fi/cellular/Ethernet transport are required.
+ */
+object RemoteConnectivityPolicy {
+    fun canStartRemoteRequest(
+        isConnected: Boolean,
+        hasPhysicalNetwork: Boolean
+    ): Boolean = isConnected && hasPhysicalNetwork
+}

--- a/shared/work/build.gradle.kts
+++ b/shared/work/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
             implementation(projects.shared.interactor)
         }
         androidMain.dependencies {
+            implementation(projects.shared.network)
             implementation(libs.bundles.work.android)
         }
     }

--- a/shared/work/src/androidMain/kotlin/org/michaelbel/movies/work/DownloadImageWorker.kt
+++ b/shared/work/src/androidMain/kotlin/org/michaelbel/movies/work/DownloadImageWorker.kt
@@ -10,16 +10,20 @@ import androidx.core.net.toUri
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
-import org.michaelbel.movies.common.ktx.currentDateTime
-import org.michaelbel.movies.interactor.AppNotificationInteractor
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import java.net.URL
+import net.i2p.android.router.util.ConnectivityAndInternetAccess
+import org.michaelbel.movies.common.ktx.currentDateTime
+import org.michaelbel.movies.interactor.AppNotificationInteractor
+import org.michaelbel.movies.network.connectivity.impl.MoviesConnectivityMonitor
 
 class DownloadImageWorker(
     private val context: Context,
     workerParams: WorkerParameters,
-    private val appNotificationInteractor: AppNotificationInteractor
+    private val appNotificationInteractor: AppNotificationInteractor,
+    private val connectivityMonitor: MoviesConnectivityMonitor
 ): CoroutineWorker(context, workerParams) {
 
     override suspend fun doWork(): Result {
@@ -29,7 +33,13 @@ class DownloadImageWorker(
         val notificationId = imageUrl.hashCode()
 
         if (imageUrl.isEmpty()) {
-            Result.failure(workDataOf(KEY_IMAGE_URL to FAILURE_RESULT))
+            return Result.failure(workDataOf(KEY_IMAGE_URL to FAILURE_RESULT))
+        }
+
+        // WorkManager also has a CONNECTED constraint, but this local guard closes the
+        // race between constraint evaluation and the actual URL.openStream() call.
+        if (!ConnectivityAndInternetAccess.isConnected(applicationContext)) {
+            return Result.retry()
         }
 
         appNotificationInteractor.sendDownloadImageNotification(
@@ -38,10 +48,19 @@ class DownloadImageWorker(
             contentTextRes = contentTextRes
         )
 
-        val uri = saveImageToDownloads(
-            url = imageUrl,
-            name = "$currentDateTime.jpg"
-        )
+        val uri = try {
+            saveImageToDownloads(
+                url = imageUrl,
+                name = "$currentDateTime.jpg"
+            )
+        } catch (failure: IOException) {
+            connectivityMonitor.onBackendTransportFailure(
+                failedHost = runCatching { URL(imageUrl).host }.getOrDefault(imageUrl),
+                failure = failure
+            )
+            appNotificationInteractor.cancelDownloadImageNotification(notificationId)
+            return Result.retry()
+        }
 
         appNotificationInteractor.cancelDownloadImageNotification(notificationId)
 

--- a/shared/work/src/androidMain/kotlin/org/michaelbel/movies/work/DownloadImageWorker.kt
+++ b/shared/work/src/androidMain/kotlin/org/michaelbel/movies/work/DownloadImageWorker.kt
@@ -17,6 +17,7 @@ import java.net.URL
 import net.i2p.android.router.util.ConnectivityAndInternetAccess
 import org.michaelbel.movies.common.ktx.currentDateTime
 import org.michaelbel.movies.interactor.AppNotificationInteractor
+import org.michaelbel.movies.network.connectivity.RemoteConnectivityPolicy
 import org.michaelbel.movies.network.connectivity.impl.MoviesConnectivityMonitor
 
 class DownloadImageWorker(
@@ -38,7 +39,11 @@ class DownloadImageWorker(
 
         // WorkManager also has a CONNECTED constraint, but this local guard closes the
         // race between constraint evaluation and the actual URL.openStream() call.
-        if (!ConnectivityAndInternetAccess.isConnected(applicationContext)) {
+        if (!RemoteConnectivityPolicy.canStartRemoteRequest(
+                isConnected = ConnectivityAndInternetAccess.isConnected(applicationContext),
+                hasPhysicalNetwork = ConnectivityAndInternetAccess.hasPhysicalNetwork(applicationContext)
+            )
+        ) {
             return Result.retry()
         }
 


### PR DESCRIPTION
**Task:**

Modernize Android connectivity handling using the latest canonical connectivity gist revision `3b0497e976765653a7467e3bd7d6bff28b96bd7c`.

- Observe Android default-network state passively with lifecycle-safe `NetworkObserver` handling.
- Apply `isConnected()` and underlying non-VPN network checks immediately before real network operations.
- Preserve the real TMDB/Ktor/OkHttp request as the source of truth; HTTP responses are not confused with transport failures.
- Handle VPN-only versus VPN-over-physical-network correctly, including `NET_CAPABILITY_NOT_VPN` and legacy compatibility.
- Run generic Internet diagnostics only after a real backend transport failure, with cooldown and single-flight protection.
- Keep the failed backend and generic Internet tiers separate for diagnostics.
- Add centralized, deduplicated Android Toast feedback for offline, recovered, captive-portal, Internet-unavailable, and backend-unavailable states.
- Keep the original request exception and TLS validation intact.
- Add/update unit coverage for fallback ordering and VPN/physical-network policy.

The implementation is intentionally limited to the existing application backend and its real request paths; no arbitrary backend health host was added.